### PR TITLE
1 move dataset of interest from published location online to s3

### DIFF
--- a/asf_mission_data_tool/config/base.yaml
+++ b/asf_mission_data_tool/config/base.yaml
@@ -1,0 +1,165 @@
+dataset:
+  energy_consumption_in_the_uk:
+    collection_url: https://www.gov.uk/government/collections/energy-consumption-in-the-uk
+    versions:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/energy_consumption_in_the_uk/ECUK_2024_Consumption_tables.xlsx
+          - s3://asf-mission-data-tool/bronze/energy_consumption_in_the_uk/ECUK_2024_Intensity_tables.xlsx
+          - s3://asf-mission-data-tool/bronze/energy_consumption_in_the_uk/ECUK_2024_Primary_Energy_tables.xlsx
+          - s3://asf-mission-data-tool/bronze/energy_consumption_in_the_uk/ECUK_2024_End_Use_tables.xlsx
+          - s3://asf-mission-data-tool/bronze/energy_consumption_in_the_uk/ECUK_2024_Electrical_Products_tables.xlsx
+        file_url:
+          - https://assets.publishing.service.gov.uk/media/66f132604f35b65bf4cffe98/ECUK_2024_Consumption_tables.xlsx
+          - https://assets.publishing.service.gov.uk/media/66f1327d02970476b261ab04/ECUK_2024_Intensity_tables.xlsx
+          - https://assets.publishing.service.gov.uk/media/66f1329802970476b261ab05/ECUK_2024_Primary_Energy_tables.xlsx
+          - https://assets.publishing.service.gov.uk/media/66f132b1b4d70bfba161ab06/ECUK_2024_End_Use_tables.xlsx
+          - https://assets.publishing.service.gov.uk/media/66f132cec9bf1d4e84379f94/ECUK_2024_Electrical_Products_tables.xlsx
+        page_url: https://www.gov.uk/government/statistics/energy-consumption-in-the-uk-2024
+        release_date: "2024-09-26"
+  energy_performance_of_buildings_certificates:
+    collection_url: https://www.gov.uk/government/collections/energy-performance-of-buildings-certificates
+    versions:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/energy_performance_of_buildings_certificates/A1-_All_Properties.ods
+          - s3://asf-mission-data-tool/bronze/energy_performance_of_buildings_certificates/D1-_Domestic_Properties.ods
+          - s3://asf-mission-data-tool/bronze/energy_performance_of_buildings_certificates/D2-_Domestic_Properties.ods
+          - s3://asf-mission-data-tool/bronze/energy_performance_of_buildings_certificates/D3-_Domestic_Properties.ods
+          - s3://asf-mission-data-tool/bronze/energy_performance_of_buildings_certificates/D4A-_Domestic_Properties.ods
+          - s3://asf-mission-data-tool/bronze/energy_performance_of_buildings_certificates/D4B-_Domestic_Properties.ods
+        file_url:
+          - https://assets.publishing.service.gov.uk/media/6717644696def6d27a4c9b6e/A1-_All_Properties.ods
+          - https://assets.publishing.service.gov.uk/media/67176490720eec5582849bad/D1-_Domestic_Properties.ods
+          - https://assets.publishing.service.gov.uk/media/671765a99242eecc6c849bb4/D2-_Domestic_Properties.ods
+          - https://assets.publishing.service.gov.uk/media/671765924a6b12291ed99875/D3-_Domestic_Properties.ods
+          - https://assets.publishing.service.gov.uk/media/671765c4583ef2380ad99880/D4A-_Domestic_Properties.ods
+          - https://assets.publishing.service.gov.uk/media/67176653d100972c0f4c9b64/D4B-_Domestic_Properties.ods
+        page_url: https://www.gov.uk/government/statistical-data-sets/live-tables-on-energy-performance-of-buildings-certificates
+        release_date: "2024-10-24"
+  energy_price_cap_levels:
+    collection_url: https://www.ofgem.gov.uk/energy-policy-and-regulation/policy-and-regulatory-programmes/energy-price-cap-default-tariff-policy/energy-price-cap-default-tariff-levels
+    versions:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/energy_price_cap_levels/Annex_9_-_Levelisation_allowance_methodology_and_levelised_cap_levels_v1.4.xlsx
+        file_url:
+          - https://www.ofgem.gov.uk/sites/default/files/2024-11/Annex_9_-_Levelisation_allowance_methodology_and_levelised_cap_levels_v1.4.xlsx
+        page_url: https://www.ofgem.gov.uk/energy-policy-and-regulation/policy-and-regulatory-programmes/energy-price-cap-default-tariff-policy/energy-price-cap-default-tariff-levels
+        release_date: "2024-11-22"
+  fuel_poverty_statistics:
+    collection_url: https://www.gov.uk/government/collections/fuel-poverty-statistics
+    versions:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/fuel_poverty_statistics/2023-fuel-poverty-detailed-tables-xls.xlsx
+        file_url:
+          - https://assets.publishing.service.gov.uk/media/65cca543130549000c8679b9/2023-fuel-poverty-detailed-tables-xls.xlsx
+        page_url: https://www.gov.uk/government/statistics/fuel-poverty-detailed-tables-2024-2023-data
+        release_date: "2024-02-15"
+  future_energy_scenarios:
+    collection_url: https://www.neso.energy/publications/future-energy-scenarios-fes
+    versions:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/future_energy_scenarios/Future Energy Scenarios
+            2024 Data Workbook_V003.xlsx
+        file_url:
+          - https://www.neso.energy/fes-data-workbook-2024
+        page_url: https://www.neso.energy/publications/future-energy-scenarios-fes
+        release_date: "2024-07-15"
+  heat_pump_deployment_quarterly_statistics:
+    collection_url: https://www.gov.uk/government/collections/heat-pump-deployment-statistics
+    versions:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/heat_pump_deployment_quarterly_statistics/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2024_Q3.xlsx
+        file_url:
+          - https://assets.publishing.service.gov.uk/media/674ddaf51916486d54daf085/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2024_Q3.xlsx
+        page_url: https://www.gov.uk/government/statistics/heat-pump-deployment-statistics-september-2024
+        release_date: "2024-12-05"
+      - file_url: https://assets.publishing.service.gov.uk/media/66f53fee080bdf716392e93f/Heat_pump_deployment_quarterly_statistics_United_Kingdom_June_2024.xlsx
+        page_url: https://www.gov.uk/government/statistics/heat-pump-deployment-statistics-june-2024
+        release_date: "2024-09-26"
+  northern_ireland_statistics_and_research_agency_census:
+    collection_url: https://www.nisra.gov.uk/statistics/census
+    versions:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/northern_ireland_statistics_and_research_agency_census/census-2021-commissioned-table-ct0082.xlsx
+        file_url:
+          - https://www.nisra.gov.uk/system/files/statistics/census-2021-commissioned-table-ct0082.xlsx
+        page_url: https://www.nisra.gov.uk/publications/census-2021-commissioned-table-ct0082
+        release_date: "2024-02-12"
+  public_attitudes_tracking_survey:
+    collection_url: https://www.gov.uk/government/collections/public-attitudes-tracking-survey
+    versions:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/public_attitudes_tracking_survey/DESNZ_PAT_Summer_2024_Time_Series.xlsx
+          - s3://asf-mission-data-tool/bronze/public_attitudes_tracking_survey/DESNZ_PAT_Summer_2024_Crosstabulations.xlsx
+        file_url:
+          - https://assets.publishing.service.gov.uk/media/671a182f593bb124be9c13dc/DESNZ_PAT_Summer_2024_Time_Series.xlsx
+          - https://assets.publishing.service.gov.uk/media/671a181a593bb124be9c13db/DESNZ_PAT_Summer_2024_Crosstabulations.xlsx
+        page_url: https://www.gov.uk/government/statistics/desnz-public-attitudes-tracker-summer-2024
+        release_date: "2024-10-29"
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/public_attitudes_tracking_survey/DESNZ_PAT_Spring_2024_Time_series.xlsx
+          - s3://asf-mission-data-tool/bronze/public_attitudes_tracking_survey/DESNZ_PAT__Spring_2024__Crosstabulations.xlsx
+        file_url:
+          - https://assets.publishing.service.gov.uk/media/6682749697ea0c79abfe4dc0/DESNZ_PAT_Spring_2024_Time_series.xlsx
+          - https://assets.publishing.service.gov.uk/media/668274ab7d26b2be17a4b4c1/DESNZ_PAT__Spring_2024__Crosstabulations.xlsx
+        page_url: https://www.gov.uk/government/statistics/desnz-public-attitudes-tracker-spring-2024
+        release_date: "2024-07-03"
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/public_attitudes_tracking_survey/DESNZ_Public_Attitudes_Tracker_Winter_2023_Time_Series.xlsx
+          - s3://asf-mission-data-tool/bronze/public_attitudes_tracking_survey/DESNZ_Public_Attitudes_Tracker_Winter_2023_Crosstabulations__Revised_July_2024_.xlsx
+        file_url:
+          - https://assets.publishing.service.gov.uk/media/65e88e6062ff48001a87b2b2/DESNZ_Public_Attitudes_Tracker_Winter_2023_Time_Series.xlsx
+          - https://assets.publishing.service.gov.uk/media/66829a4e7d26b2be17a4b4f2/DESNZ_Public_Attitudes_Tracker_Winter_2023_Crosstabulations__Revised_July_2024_.xlsx
+        page_url: https://www.gov.uk/government/statistics/desnz-public-attitudes-tracker-winter-2023
+        release_date: "2024-03-07"
+  scottish_house_condition_survey:
+    collection_url: https://www.gov.scot/collections/scottish-house-condition-survey/
+    versions:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/scottish_house_condition_survey/SHCS%2B2023-%2BChapter%2B01%2BKey%2BAttributes%2Bof%2Bthe%2BScottish%2BHousing%2BStock%2B%25E2%2580%2593%2Btables%2Band%2Bfigures.ods
+          - s3://asf-mission-data-tool/bronze/scottish_house_condition_survey/SHCS%2B2023-%2BChapter%2B02%2BEnergy%2BEfficiency-%2Btables%2Band%2Bfigures.ods
+          - s3://asf-mission-data-tool/bronze/scottish_house_condition_survey/SHCS%2B2023-%2BChapter%2B03%2BFuel%2BPoverty-%2Btables%2Band%2Bfigures.ods
+          - s3://asf-mission-data-tool/bronze/scottish_house_condition_survey/SHCS%2B2023-%2BChapter%2B04%2BEnergy%2BPerceptions-%2Btables%2Band%2Bfigures.ods
+          - s3://asf-mission-data-tool/bronze/scottish_house_condition_survey/SHCS%2B2023-%2BChapter%2B05%2BHousing%2BConditions%2B-%2Btables%2Band%2Bfigures.ods
+          - s3://asf-mission-data-tool/bronze/scottish_house_condition_survey/SHCS%2B2023-%2BChapter%2B06%2BBedroom%2BStandard-%2Btables%2Band%2Bfigures.ods
+        file_url:
+          - https://www.gov.scot/binaries/content/documents/govscot/publications/statistics/2025/01/scottish-house-condition-survey-2023-key-findings/documents/shcs-2023--chapter-01-key-attributes-of-the-scottish-housing-stock---tables-and-figures/shcs-2023--chapter-01-key-attributes-of-the-scottish-housing-stock---tables-and-figures/govscot%3Adocument/SHCS%2B2023-%2BChapter%2B01%2BKey%2BAttributes%2Bof%2Bthe%2BScottish%2BHousing%2BStock%2B%25E2%2580%2593%2Btables%2Band%2Bfigures.ods
+          - https://www.gov.scot/binaries/content/documents/govscot/publications/statistics/2025/01/scottish-house-condition-survey-2023-key-findings/documents/shcs-2023-chapter-02-energy-efficiency--tables-and-figures/shcs-2023-chapter-02-energy-efficiency--tables-and-figures/govscot%3Adocument/SHCS%2B2023-%2BChapter%2B02%2BEnergy%2BEfficiency-%2Btables%2Band%2Bfigures.ods
+          - https://www.gov.scot/binaries/content/documents/govscot/publications/statistics/2025/01/scottish-house-condition-survey-2023-key-findings/documents/shcs-2023--chapter-03-fuel-poverty--tables-and-figures/shcs-2023--chapter-03-fuel-poverty--tables-and-figures/govscot%3Adocument/SHCS%2B2023-%2BChapter%2B03%2BFuel%2BPoverty-%2Btables%2Band%2Bfigures.ods
+          - https://www.gov.scot/binaries/content/documents/govscot/publications/statistics/2025/01/scottish-house-condition-survey-2023-key-findings/documents/shcs-2023--chapter-04-energy-perceptions--tables-and-figures/shcs-2023--chapter-04-energy-perceptions--tables-and-figures/govscot%3Adocument/SHCS%2B2023-%2BChapter%2B04%2BEnergy%2BPerceptions-%2Btables%2Band%2Bfigures.ods
+          - https://www.gov.scot/binaries/content/documents/govscot/publications/statistics/2025/01/scottish-house-condition-survey-2023-key-findings/documents/shcs-2023--chapter-05-housing-conditions---tables-and-figures/shcs-2023--chapter-05-housing-conditions---tables-and-figures/govscot%3Adocument/SHCS%2B2023-%2BChapter%2B05%2BHousing%2BConditions%2B-%2Btables%2Band%2Bfigures.ods
+          - https://www.gov.scot/binaries/content/documents/govscot/publications/statistics/2025/01/scottish-house-condition-survey-2023-key-findings/documents/shcs-2023--chapter-06-bedroom-standard--tables-and-figures/shcs-2023--chapter-06-bedroom-standard--tables-and-figures/govscot%3Adocument/SHCS%2B2023-%2BChapter%2B06%2BBedroom%2BStandard-%2Btables%2Band%2Bfigures.ods
+        page_url: https://www.gov.scot/publications/scottish-house-condition-survey-2023-key-findings/documents/
+        release_date: "2025-01-28"
+  sixth_carbon_budget:
+    collection_url: https://www.theccc.org.uk/publication/sixth-carbon-budget/
+    versions:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/sixth_carbon_budget/The-Sixth-Carbon-Budget-Dataset_v2.xlsx
+        file_url:
+          - https://www.theccc.org.uk/wp-content/uploads/2020/12/The-Sixth-Carbon-Budget-Dataset_v2.xlsx
+        page_url: https://www.theccc.org.uk/publication/sixth-carbon-budget/#supporting-information-charts-and-data
+        release_date: "2020-12-09"
+  uk_territorial_greenhouse_gas_emissions_statistics:
+    collection_url: https://www.gov.uk/government/collections/uk-territorial-greenhouse-gas-emissions-statistics
+    versions:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/uk_territorial_greenhouse_gas_emissions_statistics/2023-provisional-emissions-data-tables.xlsx
+        file_url:
+          - https://assets.publishing.service.gov.uk/media/660305b1c34a860011be75f2/2023-provisional-emissions-data-tables.xlsx
+        page_url: https://www.gov.uk/government/statistics/provisional-uk-greenhouse-gas-emissions-national-statistics-2023
+        release_date: "2024-03-28"
+      - file_url:
+          - https://assets.publishing.service.gov.uk/media/65ff114a65ca2ffef17da7a6/final-greenhouse-gas-emissions-tables-2022.xlsx
+          - https://assets.publishing.service.gov.uk/media/66044b8cf9ab410011eea42d/final-greenhouse-gas-emissions-end-user-tables-2022.xlsx
+          - https://assets.publishing.service.gov.uk/media/667bec4297ea0c79abfe4c72/sic-final-greenhouse-gas-emissions-tables-2022.xlsx
+        page_url: https://www.gov.uk/government/statistics/final-uk-greenhouse-gas-emissions-national-statistics-1990-to-2022
+        release_date: "2024-02-06"
+  welsh_housing_conditions_survey:
+    collection_url: https://www.gov.wales/welsh-housing-conditions-survey
+    versions:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/welsh_housing_conditions_survey/welsh-housing-conditions-survey-results-viewer-2017-18-en.ods
+        file_url:
+          - https://www.gov.wales/sites/default/files/statistics-and-research/2019-11/welsh-housing-conditions-survey-results-viewer-2017-18-en.ods
+        page_url: https://www.gov.wales/welsh-housing-conditions-survey-results-viewer
+        release_date: "2018-12-20"

--- a/asf_mission_data_tool/config/base.yaml
+++ b/asf_mission_data_tool/config/base.yaml
@@ -130,6 +130,15 @@ dataset:
           - https://www.gov.scot/binaries/content/documents/govscot/publications/statistics/2025/01/scottish-house-condition-survey-2023-key-findings/documents/shcs-2023--chapter-06-bedroom-standard--tables-and-figures/shcs-2023--chapter-06-bedroom-standard--tables-and-figures/govscot%3Adocument/SHCS%2B2023-%2BChapter%2B06%2BBedroom%2BStandard-%2Btables%2Band%2Bfigures.ods
         page_url: https://www.gov.scot/publications/scottish-house-condition-survey-2023-key-findings/documents/
         release_date: "2025-01-28"
+  seventh_carbon_budget:
+    collection_url: https://www.theccc.org.uk/publication/the-seventh-carbon-budget/
+    versions:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/seventh_carbon_budget/The-Seventh-Carbon-Budget-full-dataset.xlsx
+        file_url:
+          - https://www.theccc.org.uk/wp-content/uploads/2025/02/The-Seventh-Carbon-Budget-full-dataset.xlsx
+        page_url: https://www.theccc.org.uk/publication/the-seventh-carbon-budget/#publication-downloads
+        release_date: "2025-02-26"
   sixth_carbon_budget:
     collection_url: https://www.theccc.org.uk/publication/sixth-carbon-budget/
     versions:

--- a/asf_mission_data_tool/getters/data_getters.py
+++ b/asf_mission_data_tool/getters/data_getters.py
@@ -1,0 +1,284 @@
+import requests
+import boto3
+import subprocess
+import toml
+import logging
+import yaml
+from botocore.exceptions import NoCredentialsError, ClientError
+from datetime import datetime
+from typing import Callable, Any, Optional, Dict
+from asf_mission_data_tool import config
+
+# Suppress information level messages from botocore
+logging.getLogger("botocore.credentials").setLevel(logging.ERROR)
+
+
+def _save_provenance_to_toml(func: Callable[..., Any]) -> Callable[..., Any]:
+    """
+    A decorator function that adds provenance metadata to an S3 file upload operation.
+    The following metadata about the downloaded file is captured:
+    - Original file URL
+    - Download date and time
+    - Git user who downloaded the file
+    This function generates a TOML file containing this metadata and uploads it to an S3 bucket.
+    If a TOML file already exists in the bucket, the user is prompted to confirm whether to overwrite it.
+
+    Parameters
+    ----------
+    func : Callable[..., Any]
+        The decorated function that performs the primary operation, such as uploading a file to S3.
+
+    Returns
+    -------
+    Callable[..., Any]
+        The wrapper function that adds metadata handling to the original function.
+
+    Raises
+    -------
+    Exception: If any error occurs during the file upload or metadata generation process.
+
+    """
+
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+
+        # Execute inner function
+        result = func(*args, **kwargs)
+
+        # Extract information from arguments
+        dataset_name = kwargs.get("dataset_name", "")
+        target_url = kwargs.get("target_url", "")
+
+        # Prepare provenance metadata
+        metadata = {
+            "original_file_url": target_url,
+            "download_date_time": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            "downloaded_by_git_user": subprocess.check_output(
+                ["git", "config", "--global", "user.name"]
+            )
+            .strip()
+            .decode("utf-8"),
+        }
+
+        # Convert to TOML format
+        toml_content = toml.dumps(metadata)
+
+        # Define S3 path for .toml file
+        file_name = target_url.split("/")[-1]
+        toml_file_name = file_name.rsplit(".", 1)[0] + ".toml"
+        toml_file_path = f"bronze/{dataset_name}/{toml_file_name}"
+
+        # Upload to S3
+        s3_client = boto3.client("s3")
+
+        # Check if .toml file already exists in S3 bucket
+        try:
+            s3_client.head_object(Bucket="asf-mission-data-tool", Key=toml_file_path)
+            toml_exists = True
+        except ClientError as error:
+            if error.response["Error"]["Code"] == "404":
+                toml_exists = False
+            else:
+                # Raise if other error
+                raise
+
+        # If .toml file exists, prompt user to confirm overwrite
+        if toml_exists:
+            overwrite = input(
+                f"File s3://asf-mission-data-tool/{toml_file_path} already exists. Do you want to overwrite it? (y/n): "
+            )
+            if overwrite.lower() != "y":
+                print("Metadata file not overwritten. Aborting upload.")
+                return  # Abort the function
+
+        # Proceed with uploading .toml file
+        try:
+            s3_client.put_object(
+                Bucket="asf-mission-data-tool", Key=toml_file_path, Body=toml_content
+            )
+            print(
+                f"Provenance metadata saved to s3://asf-mission-data-tool/{toml_file_path}"
+            )
+        except NoCredentialsError:
+            print("Credentials not available.")
+        except Exception as e:
+            print(f"Error uploading metadata file: {e}")
+
+        return result
+
+    wrapper.__name__ = func.__name__
+    wrapper.__doc__ = func.__doc__
+
+    return wrapper
+
+
+@_save_provenance_to_toml
+def save_to_s3_bronze(dataset_name: str, target_url: str) -> str:
+    """
+    Downloads a file from a given URL and uploads it to the S3 bucket "asf-mission-data-tool".
+    This function checks if the file already exists in the S3 bucket:
+    - If the file exists and the size matches, it will ask the user if they want to overwrite it.
+    - If the file exists but the size differs, it will ask the user if they still want to overwrite it.
+    - If the file doesn't exist, it will upload the file.
+    Additionally, it calls the `save_provenance_to_toml` decorator to save metadata about the file in a sidecar .toml file.
+    Parameters
+    ----------
+    dataset_name : str
+        The name of the dataset used for the S3 path; fixed, unique identifier to identify any instance of the dataset.
+    target_url : str
+        The URL of the file to be downloaded and uploaded to S3.
+
+    Returns
+    -------
+    str
+        File path where bronze data has been saved in s3.
+
+    Raises
+    -------
+    Exception: If there are issues downloading the file, uploading to S3, or checking the file's existence.
+
+    """
+
+    # Download target file
+    with requests.get(target_url) as response:
+        if response.status_code == 200:
+            file_content = response.content
+        else:
+            print(f"Failed to download file. Status code: {response.status_code}")
+            return
+
+    # Upload to S3
+    s3_client = boto3.client("s3")
+
+    # Get file name from URL or response headers
+    if "Content-Disposition" in response.headers:
+        content_disposition = response.headers["Content-Disposition"]
+        file_name = content_disposition.split("filename=")[-1].strip('"')
+    else:
+        file_name = target_url.split("/")[-1]
+
+    # Define S3 path for main file
+    main_file_path = f"bronze/{dataset_name}/{file_name}"
+
+    # Check if file already exists in S3 bucket
+    try:
+        response = s3_client.head_object(
+            Bucket="asf-mission-data-tool", Key=main_file_path
+        )
+        # If no ClientError is raised, the file exists
+        file_exists = True
+        existing_file_size = response["ContentLength"]
+    except ClientError as error:
+        # If the ClientError code is 404, the file does not exist
+        if error.response["Error"]["Code"] == "404":
+            file_exists = False
+        else:
+            # Raise if other error
+            raise
+
+    # If main file exists, check if sizes match and prompt user to confirm overwrite
+    if file_exists:
+        local_file_size = len(file_content)
+        if existing_file_size == local_file_size:
+            print(
+                f"File s3://asf-mission-data-tool/{main_file_path} already exists and has the same size."
+            )
+            overwrite = input(f"Do you want to overwrite it? (y/n): ")
+            if overwrite.lower() != "y":
+                print("Main file not overwritten. Aborting upload.")
+                return  # Abort the function
+        else:
+            print(
+                f"File s3://asf-mission-data-tool/{main_file_path} exists, but sizes do not match."
+            )
+            overwrite = input(f"Do you still want to overwrite it? (y/n): ")
+            if overwrite.lower() != "y":
+                print("Main file not overwritten. Aborting upload.")
+                return  # Abort the function
+
+    # Upload main file to S3 if file does not exist or overwrite confirmed
+    try:
+        s3_client.put_object(
+            Bucket="asf-mission-data-tool", Key=main_file_path, Body=file_content
+        )
+        print(
+            f"File uploaded successfully to s3://asf-mission-data-tool/{main_file_path}"
+        )
+    except NoCredentialsError:
+        print("Credentials not available.")
+    except Exception as e:
+        print(f"Error uploading file: {e}")
+
+    return f"s3://asf-mission-data-tool/{main_file_path}"
+
+
+def get_latest_version(dataset_name: str, filter: Optional[str] = None) -> Dict:
+    """Returns the latest version of a dataset instance from config.
+
+    Parameters
+    ----------
+    dataset_name : str
+        Name of dataset; must be a key of dataset in config/base.yaml.
+
+    filter : Optional[str], default None
+        Word to filter file URLs if only interested in gettgin the latest version of one particular category in the dataset.
+
+    Returns
+    -------
+    Dict
+        Dictionary with key-value pairs for dataset release date, file url and page url.
+    """
+    versions = config.get("dataset").get(dataset_name).get("versions")
+
+    if filter:
+        filtered_versions = [
+            version
+            for version in versions
+            if any(filter in url for url in version["file_url"])
+        ]
+        latest_version = max(
+            filtered_versions,
+            key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d"),
+        )
+    else:
+        latest_version = max(
+            versions, key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d")
+        )
+    return latest_version
+
+
+def append_file_bronze_to_latest_version(
+    dataset_name: str,
+    s3_file_path: str,
+    filter: Optional[str] = None,
+) -> None:
+
+    # Load existing config data
+    with open("asf_mission_data_tool/config/base.yaml", "r") as file:
+        all_existing_data = yaml.safe_load(file)
+
+    # Update data
+    dataset_specific_data = all_existing_data.get("dataset", {}).get(dataset_name, {})
+    versions = dataset_specific_data.get("versions", [])
+    if filter:
+        filtered_versions = [
+            version
+            for version in versions
+            if any(filter in url for url in version["file_url"])
+        ]
+        latest_version = max(
+            filtered_versions,
+            key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d"),
+        )
+    else:
+        latest_version = max(
+            versions, key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d")
+        )
+    latest_version["file_bronze"] = s3_file_path
+
+    # Write updated data to .yaml
+    with open("asf_mission_data_tool/config/base.yaml", "w") as file:
+        yaml.dump(all_existing_data, file, default_flow_style=False, sort_keys=True)
+
+    print(
+        f"file_bronze field added to version with release_date {latest_version['release_date']}."
+    )

--- a/asf_mission_data_tool/getters/data_getters.py
+++ b/asf_mission_data_tool/getters/data_getters.py
@@ -4,6 +4,8 @@ import subprocess
 import toml
 import logging
 import yaml
+import io
+import pandas as pd
 from botocore.exceptions import NoCredentialsError, ClientError
 from datetime import datetime
 from typing import Callable, Any, Optional, Dict
@@ -11,6 +13,147 @@ from asf_mission_data_tool import config
 
 # Suppress information level messages from botocore
 logging.getLogger("botocore.credentials").setLevel(logging.ERROR)
+
+
+"""
+General
+"""
+
+
+def get_latest_version(dataset_name: str, filter: Optional[str] = None) -> Dict:
+    """Returns the latest version of a dataset instance from config.
+
+    Parameters
+    ----------
+    dataset_name : str
+        Name of dataset; must be a key of dataset in config/base.yaml.
+
+    filter : Optional[str], default None
+        Word to filter file URLs if only interested in gettgin the latest version of one particular category in the dataset.
+
+    Returns
+    -------
+    Dict
+        Dictionary with key-value pairs for dataset release date, file url and page url.
+    """
+    versions = config.get("dataset").get(dataset_name).get("versions")
+    if not versions:
+        raise ValueError(f"No versions found for dataset '{dataset_name}'.")
+
+    if filter:
+        filtered_versions = [
+            version
+            for version in versions
+            if any(filter in url for url in version["file_url"])
+        ]
+        if not filtered_versions:
+            raise ValueError(f"No versions found matching filter '{filter}'.")
+        latest_version = max(
+            filtered_versions,
+            key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d"),
+        )
+    else:
+        latest_version = max(
+            versions, key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d")
+        )
+    return latest_version
+
+
+def append_field_to_latest_version(
+    dataset_name: str,
+    s3_file_path: str,
+    new_field_name: str,
+    filter: Optional[str] = None,
+) -> None:
+    """Updates the base.yaml configuration file by appending a new field to the latest version entry of a specified dataset.
+    The function reads the dataset details from an existing config file, determines the latest version based on the release date and
+    updates the entry with the provided S3 file path.
+
+    Parameters
+    ----------
+    dataset_name : str
+        Name of dataset; must be a key of dataset in config/base.yaml.
+    s3_file_path : str
+        The S3 path of the silver dataset file.
+    new_field_name : str
+        The name of the new field to append to the base.yaml configuration file for the dataset of interest.
+    filter : Optional[str], optional
+        An optional filter to select specific dataset versions based on file URLs, by default None.
+    """
+
+    try:
+        # Load existing config data
+        with open("asf_mission_data_tool/config/base.yaml", "r") as file:
+            all_existing_data = yaml.safe_load(file)
+    except FileNotFoundError:
+        raise FileNotFoundError("The configuration file 'base.yaml' was not found.")
+    except yaml.YAMLError:
+        raise ValueError("Error parsing YAML file. Please check its formatting.")
+
+    # Retrieve entry for dataset
+    dataset_specific_data = all_existing_data.get("dataset", {}).get(dataset_name, {})
+    if not dataset_specific_data:
+        raise KeyError(f"Dataset '{dataset_name}' not found in config file.")
+
+    versions = dataset_specific_data.get("versions", [])
+    if not versions:
+        raise ValueError(f"No versions found for dataset '{dataset_name}'.")
+
+    # Retrieve latest version of dataset
+    if filter:
+        filtered_versions = [
+            version
+            for version in versions
+            if any(filter in url for url in version["file_url"])
+        ]
+        if not filtered_versions:
+            raise ValueError(f"No versions found matching filter '{filter}'.")
+        latest_version = max(
+            filtered_versions,
+            key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d"),
+        )
+    else:
+        latest_version = max(
+            versions, key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d")
+        )
+    latest_version[new_field_name] = s3_file_path
+
+    # Write updated data
+    with open("asf_mission_data_tool/config/base.yaml", "w") as file:
+        yaml.dump(
+            all_existing_data,
+            file,
+            default_flow_style=False,
+            sort_keys=True,
+        )
+
+    print(
+        f"{new_field_name} field added to version with release_date {latest_version['release_date']}."
+    )
+
+
+def get_from_s3(s3_key: str) -> io.BytesIO:
+    """Downloads a file from the asf-mission-data-tool S3 bucket and returns it as a BytesIO object.
+
+    Parameters
+    ----------
+    s3_file_path : str
+        The S3 key (file path) within the bucket.
+
+    Returns
+    -------
+    io.BytesIO
+        A file-like object containing the file content.
+    """
+    s3 = boto3.client("s3")
+    obj = s3.get_object(Bucket="asf-mission-data-tool", Key=s3_key)
+    content = io.BytesIO(obj["Body"].read())
+    return content
+
+
+"""
+Bronze
+"""
 
 
 def _save_provenance_to_toml(func: Callable[..., Any]) -> Callable[..., Any]:
@@ -211,105 +354,74 @@ def save_to_s3_bronze(dataset_name: str, target_url: str) -> str:
     return f"s3://asf-mission-data-tool/{main_file_path}"
 
 
-def get_latest_version(dataset_name: str, filter: Optional[str] = None) -> Dict:
-    """Returns the latest version of a dataset instance from config.
+"""
+Silver
+"""
+
+
+def save_to_s3_silver(
+    dataframe: pd.DataFrame,
+    dataset_name: str,
+    main_file_dict: Dict,
+    subset_id: str,
+) -> str:
+    """Saves a given Pandas DataFrame to the asf_mission_data_tool S3 bucket in parquet format. The file is stored in both
+    the "LATEST" directory and a date-specific archive directory.
 
     Parameters
     ----------
+    dataframe : pd.DataFrame
+    Dataframe to be saved.
     dataset_name : str
         Name of dataset; must be a key of dataset in config/base.yaml.
-
-    filter : Optional[str], default None
-        Word to filter file URLs if only interested in gettgin the latest version of one particular category in the dataset.
+    main_file_dict : Dict
+        Dictionary containing dataset metadata from config/base.yaml.
+    subset_id : str
+        An identifier for the subset of the dataset.
 
     Returns
     -------
-    Dict
-        Dictionary with key-value pairs for dataset release date, file url and page url.
-    """
-    versions = config.get("dataset").get(dataset_name).get("versions")
-    if not versions:
-        raise ValueError(f"No versions found for dataset '{dataset_name}'.")
-
-    if filter:
-        filtered_versions = [
-            version
-            for version in versions
-            if any(filter in url for url in version["file_url"])
-        ]
-        if not filtered_versions:
-            raise ValueError(f"No versions found matching filter '{filter}'.")
-        latest_version = max(
-            filtered_versions,
-            key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d"),
-        )
-    else:
-        latest_version = max(
-            versions, key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d")
-        )
-    return latest_version
-
-
-def append_file_bronze_to_latest_version(
-    dataset_name: str,
-    s3_file_path: str,
-    filter: Optional[str] = None,
-) -> None:
-    """Updates the base.yaml configuration file by appending a "file_bronze" field to the latest version entry of a specified dataset.
-    The function reads the dataset details from an existing config file, determines the latest version based on the release date and
-    updates the entry with the provided S3 file path.
-
-    Parameters
-    ----------
-    dataset_name : str
-        Name of dataset; must be a key of dataset in config/base.yaml.
-    s3_file_path : str
-        The S3 path of the bronze dataset file.
-    filter : Optional[str], optional
-        An optional filter to select specific dataset versions based on file URLs, by default None.
+    str
+        The S3 URI of the saved parquet file
     """
 
-    try:
-        # Load existing config data
-        with open("asf_mission_data_tool/config/base.yaml", "r") as file:
-            all_existing_data = yaml.safe_load(file)
-    except FileNotFoundError:
-        raise FileNotFoundError("The configuration file 'base.yaml' was not found.")
-    except yaml.YAMLError:
-        raise ValueError("Error parsing YAML file. Please check its formatting.")
+    # Extract file information
+    file_name = main_file_dict.get("file_url")[0].split("/")[-1].rsplit(".", 1)[0]
+    archive_date = pd.to_datetime(main_file_dict.get("release_date")).strftime("%B_%Y")
 
-    # Retrieve entry for dataset
-    dataset_specific_data = all_existing_data.get("dataset", {}).get(dataset_name, {})
-    if not dataset_specific_data:
-        raise KeyError(f"Dataset '{dataset_name}' not found in config file.")
+    s3_client = boto3.client("s3")
 
-    versions = dataset_specific_data.get("versions", [])
-    if not versions:
-        raise ValueError(f"No versions found for dataset '{dataset_name}'.")
-
-    # Retrieve latest version of dataset
-    if filter:
-        filtered_versions = [
-            version
-            for version in versions
-            if any(filter in url for url in version["file_url"])
-        ]
-        if not filtered_versions:
-            raise ValueError(f"No versions found matching filter '{filter}'.")
-        latest_version = max(
-            filtered_versions,
-            key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d"),
-        )
-    else:
-        latest_version = max(
-            versions, key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d")
-        )
-    latest_version["file_bronze"] = s3_file_path
-
-    # Write updated data
-    with open("asf_mission_data_tool/config/base.yaml", "w") as file:
-        yaml.dump(all_existing_data, file, default_flow_style=False, sort_keys=True)
-
-    print(
-        f"file_bronze field added to version with release_date {latest_version['release_date']}."
+    # Save to LATEST/ and archive date/
+    latest_key = f"silver/{dataset_name}/LATEST/{file_name}_{subset_id}.parquet"
+    archive_key = (
+        f"silver/{dataset_name}/{archive_date}/{file_name}_{subset_id}.parquet"
     )
+
+    with io.BytesIO() as parquet_buffer:
+
+        dataframe.to_parquet(parquet_buffer, engine="pyarrow", index=False)
+        parquet_buffer.seek(0)
+
+        try:
+            s3_client.put_object(
+                Bucket="asf-mission-data-tool",
+                Key=latest_key,
+                Body=parquet_buffer.getvalue(),
+            )
+            print(
+                f"File uploaded successfully to s3://asf-mission-data-tool/{latest_key}"
+            )
+            s3_client.put_object(
+                Bucket="asf-mission-data-tool",
+                Key=archive_key,
+                Body=parquet_buffer.getvalue(),
+            )
+            print(
+                f"File uploaded successfully to s3://asf-mission-data-tool/{archive_key}"
+            )
+        except NoCredentialsError:
+            print("Credentials not available.")
+        except Exception as e:
+            print(f"Error uploading file: {e}")
+
+    return f"s3://asf-mission-data-tool/{archive_key}"

--- a/asf_mission_data_tool/pipeline/energy_consumption_in_the_uk_pipeline/get_energy_consumption_in_the_uk_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/energy_consumption_in_the_uk_pipeline/get_energy_consumption_in_the_uk_to_bronze.py
@@ -1,0 +1,22 @@
+from asf_mission_data_tool.getters.data_getters import (
+    save_to_s3_bronze,
+    get_latest_version,
+    append_file_bronze_to_latest_version,
+)
+
+dataset_name = "energy_consumption_in_the_uk"
+
+latest_version = get_latest_version(dataset_name)
+
+s3_file_path = []
+for file_url in latest_version.get("file_url"):
+    file_path = save_to_s3_bronze(dataset_name=dataset_name, target_url=file_url)
+    if file_path:
+        s3_file_path.append(file_path)
+
+if not s3_file_path:
+    pass
+else:
+    append_file_bronze_to_latest_version(
+        dataset_name=dataset_name, s3_file_path=s3_file_path
+    )

--- a/asf_mission_data_tool/pipeline/energy_consumption_in_the_uk_pipeline/get_energy_consumption_in_the_uk_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/energy_consumption_in_the_uk_pipeline/get_energy_consumption_in_the_uk_to_bronze.py
@@ -1,7 +1,7 @@
 from asf_mission_data_tool.getters.data_getters import (
     save_to_s3_bronze,
     get_latest_version,
-    append_file_bronze_to_latest_version,
+    append_field_to_latest_version,
 )
 
 dataset_name = "energy_consumption_in_the_uk"
@@ -17,6 +17,8 @@ for file_url in latest_version.get("file_url"):
 if not s3_file_path:
     pass
 else:
-    append_file_bronze_to_latest_version(
-        dataset_name=dataset_name, s3_file_path=s3_file_path
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_bronze",
     )

--- a/asf_mission_data_tool/pipeline/energy_performance_of_buildings_certificates_pipeline/get_energy_performance_of_buildings_certificates_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/energy_performance_of_buildings_certificates_pipeline/get_energy_performance_of_buildings_certificates_to_bronze.py
@@ -1,0 +1,22 @@
+from asf_mission_data_tool.getters.data_getters import (
+    save_to_s3_bronze,
+    get_latest_version,
+    append_file_bronze_to_latest_version,
+)
+
+dataset_name = "energy_performance_of_buildings_certificates"
+
+latest_version = get_latest_version(dataset_name)
+
+s3_file_path = []
+for file_url in latest_version.get("file_url"):
+    file_path = save_to_s3_bronze(dataset_name=dataset_name, target_url=file_url)
+    if file_path:
+        s3_file_path.append(file_path)
+
+if not s3_file_path:
+    pass
+else:
+    append_file_bronze_to_latest_version(
+        dataset_name=dataset_name, s3_file_path=s3_file_path
+    )

--- a/asf_mission_data_tool/pipeline/energy_performance_of_buildings_certificates_pipeline/get_energy_performance_of_buildings_certificates_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/energy_performance_of_buildings_certificates_pipeline/get_energy_performance_of_buildings_certificates_to_bronze.py
@@ -1,7 +1,7 @@
 from asf_mission_data_tool.getters.data_getters import (
     save_to_s3_bronze,
     get_latest_version,
-    append_file_bronze_to_latest_version,
+    append_field_to_latest_version,
 )
 
 dataset_name = "energy_performance_of_buildings_certificates"
@@ -17,6 +17,8 @@ for file_url in latest_version.get("file_url"):
 if not s3_file_path:
     pass
 else:
-    append_file_bronze_to_latest_version(
-        dataset_name=dataset_name, s3_file_path=s3_file_path
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_bronze",
     )

--- a/asf_mission_data_tool/pipeline/energy_price_cap_levels_pipeline/get_energy_price_cap_levels_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/energy_price_cap_levels_pipeline/get_energy_price_cap_levels_to_bronze.py
@@ -1,0 +1,22 @@
+from asf_mission_data_tool.getters.data_getters import (
+    save_to_s3_bronze,
+    get_latest_version,
+    append_file_bronze_to_latest_version,
+)
+
+dataset_name = "energy_price_cap_levels"
+
+latest_version = get_latest_version(dataset_name)
+
+s3_file_path = []
+for file_url in latest_version.get("file_url"):
+    file_path = save_to_s3_bronze(dataset_name=dataset_name, target_url=file_url)
+    if file_path:
+        s3_file_path.append(file_path)
+
+if not s3_file_path:
+    pass
+else:
+    append_file_bronze_to_latest_version(
+        dataset_name=dataset_name, s3_file_path=s3_file_path
+    )

--- a/asf_mission_data_tool/pipeline/energy_price_cap_levels_pipeline/get_energy_price_cap_levels_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/energy_price_cap_levels_pipeline/get_energy_price_cap_levels_to_bronze.py
@@ -1,7 +1,7 @@
 from asf_mission_data_tool.getters.data_getters import (
     save_to_s3_bronze,
     get_latest_version,
-    append_file_bronze_to_latest_version,
+    append_field_to_latest_version,
 )
 
 dataset_name = "energy_price_cap_levels"
@@ -17,6 +17,8 @@ for file_url in latest_version.get("file_url"):
 if not s3_file_path:
     pass
 else:
-    append_file_bronze_to_latest_version(
-        dataset_name=dataset_name, s3_file_path=s3_file_path
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_bronze",
     )

--- a/asf_mission_data_tool/pipeline/fuel_poverty_statistics/get_fuel_poverty_statistics_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/fuel_poverty_statistics/get_fuel_poverty_statistics_to_bronze.py
@@ -1,0 +1,22 @@
+from asf_mission_data_tool.getters.data_getters import (
+    save_to_s3_bronze,
+    get_latest_version,
+    append_file_bronze_to_latest_version,
+)
+
+dataset_name = "fuel_poverty_statistics"
+
+latest_version = get_latest_version(dataset_name)
+
+s3_file_path = []
+for file_url in latest_version.get("file_url"):
+    file_path = save_to_s3_bronze(dataset_name=dataset_name, target_url=file_url)
+    if file_path:
+        s3_file_path.append(file_path)
+
+if not s3_file_path:
+    pass
+else:
+    append_file_bronze_to_latest_version(
+        dataset_name=dataset_name, s3_file_path=s3_file_path
+    )

--- a/asf_mission_data_tool/pipeline/fuel_poverty_statistics/get_fuel_poverty_statistics_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/fuel_poverty_statistics/get_fuel_poverty_statistics_to_bronze.py
@@ -1,7 +1,7 @@
 from asf_mission_data_tool.getters.data_getters import (
     save_to_s3_bronze,
     get_latest_version,
-    append_file_bronze_to_latest_version,
+    append_field_to_latest_version,
 )
 
 dataset_name = "fuel_poverty_statistics"
@@ -17,6 +17,8 @@ for file_url in latest_version.get("file_url"):
 if not s3_file_path:
     pass
 else:
-    append_file_bronze_to_latest_version(
-        dataset_name=dataset_name, s3_file_path=s3_file_path
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_bronze",
     )

--- a/asf_mission_data_tool/pipeline/future_energy_scenarios_pipeline/get_future_energy_scenarios_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/future_energy_scenarios_pipeline/get_future_energy_scenarios_to_bronze.py
@@ -1,0 +1,22 @@
+from asf_mission_data_tool.getters.data_getters import (
+    save_to_s3_bronze,
+    get_latest_version,
+    append_file_bronze_to_latest_version,
+)
+
+dataset_name = "future_energy_scenarios"
+
+latest_version = get_latest_version(dataset_name)
+
+s3_file_path = []
+for file_url in latest_version.get("file_url"):
+    file_path = save_to_s3_bronze(dataset_name=dataset_name, target_url=file_url)
+    if file_path:
+        s3_file_path.append(file_path)
+
+if not s3_file_path:
+    pass
+else:
+    append_file_bronze_to_latest_version(
+        dataset_name=dataset_name, s3_file_path=s3_file_path
+    )

--- a/asf_mission_data_tool/pipeline/future_energy_scenarios_pipeline/get_future_energy_scenarios_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/future_energy_scenarios_pipeline/get_future_energy_scenarios_to_bronze.py
@@ -1,7 +1,7 @@
 from asf_mission_data_tool.getters.data_getters import (
     save_to_s3_bronze,
     get_latest_version,
-    append_file_bronze_to_latest_version,
+    append_field_to_latest_version,
 )
 
 dataset_name = "future_energy_scenarios"
@@ -17,6 +17,8 @@ for file_url in latest_version.get("file_url"):
 if not s3_file_path:
     pass
 else:
-    append_file_bronze_to_latest_version(
-        dataset_name=dataset_name, s3_file_path=s3_file_path
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_bronze",
     )

--- a/asf_mission_data_tool/pipeline/heat_pump_deployment_quarterly_statistics_pipeline/get_heat_pump_deployment_quarterly_statistics_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/heat_pump_deployment_quarterly_statistics_pipeline/get_heat_pump_deployment_quarterly_statistics_to_bronze.py
@@ -1,0 +1,22 @@
+from asf_mission_data_tool.getters.data_getters import (
+    save_to_s3_bronze,
+    get_latest_version,
+    append_file_bronze_to_latest_version,
+)
+
+dataset_name = "heat_pump_deployment_quarterly_statistics"
+
+latest_version = get_latest_version(dataset_name)
+
+s3_file_path = []
+for file_url in latest_version.get("file_url"):
+    file_path = save_to_s3_bronze(dataset_name=dataset_name, target_url=file_url)
+    if file_path:
+        s3_file_path.append(file_path)
+
+if not s3_file_path:
+    pass
+else:
+    append_file_bronze_to_latest_version(
+        dataset_name=dataset_name, s3_file_path=s3_file_path
+    )

--- a/asf_mission_data_tool/pipeline/heat_pump_deployment_quarterly_statistics_pipeline/get_heat_pump_deployment_quarterly_statistics_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/heat_pump_deployment_quarterly_statistics_pipeline/get_heat_pump_deployment_quarterly_statistics_to_bronze.py
@@ -1,7 +1,7 @@
 from asf_mission_data_tool.getters.data_getters import (
     save_to_s3_bronze,
     get_latest_version,
-    append_file_bronze_to_latest_version,
+    append_field_to_latest_version,
 )
 
 dataset_name = "heat_pump_deployment_quarterly_statistics"
@@ -17,6 +17,8 @@ for file_url in latest_version.get("file_url"):
 if not s3_file_path:
     pass
 else:
-    append_file_bronze_to_latest_version(
-        dataset_name=dataset_name, s3_file_path=s3_file_path
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_bronze",
     )

--- a/asf_mission_data_tool/pipeline/northern_ireland_statistics_and_research_agency_census/get_northern_ireland_statistics_and_research_agency_census_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/northern_ireland_statistics_and_research_agency_census/get_northern_ireland_statistics_and_research_agency_census_to_bronze.py
@@ -1,0 +1,22 @@
+from asf_mission_data_tool.getters.data_getters import (
+    save_to_s3_bronze,
+    get_latest_version,
+    append_file_bronze_to_latest_version,
+)
+
+dataset_name = "northern_ireland_statistics_and_research_agency_census"
+
+latest_version = get_latest_version(dataset_name)
+
+s3_file_path = []
+for file_url in latest_version.get("file_url"):
+    file_path = save_to_s3_bronze(dataset_name=dataset_name, target_url=file_url)
+    if file_path:
+        s3_file_path.append(file_path)
+
+if not s3_file_path:
+    pass
+else:
+    append_file_bronze_to_latest_version(
+        dataset_name=dataset_name, s3_file_path=s3_file_path
+    )

--- a/asf_mission_data_tool/pipeline/northern_ireland_statistics_and_research_agency_census/get_northern_ireland_statistics_and_research_agency_census_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/northern_ireland_statistics_and_research_agency_census/get_northern_ireland_statistics_and_research_agency_census_to_bronze.py
@@ -1,7 +1,7 @@
 from asf_mission_data_tool.getters.data_getters import (
     save_to_s3_bronze,
     get_latest_version,
-    append_file_bronze_to_latest_version,
+    append_field_to_latest_version,
 )
 
 dataset_name = "northern_ireland_statistics_and_research_agency_census"
@@ -17,6 +17,8 @@ for file_url in latest_version.get("file_url"):
 if not s3_file_path:
     pass
 else:
-    append_file_bronze_to_latest_version(
-        dataset_name=dataset_name, s3_file_path=s3_file_path
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_bronze",
     )

--- a/asf_mission_data_tool/pipeline/public_attitudes_tracking_survey_pipeline/get_public_attitudes_tracking_survey_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/public_attitudes_tracking_survey_pipeline/get_public_attitudes_tracking_survey_to_bronze.py
@@ -1,0 +1,25 @@
+from asf_mission_data_tool.getters.data_getters import (
+    save_to_s3_bronze,
+    get_latest_version,
+    append_file_bronze_to_latest_version,
+)
+
+dataset_name = "public_attitudes_tracking_survey"
+
+# PAT is a triannual survey, get version for latest Summer/Spring/Winter
+
+for season in ["Summer", "Spring", "Winter"]:
+    latest_season_version = get_latest_version(dataset_name=dataset_name, filter=season)
+
+    s3_file_path = []
+    for url in latest_season_version.get("file_url"):
+        file_path = save_to_s3_bronze(dataset_name=dataset_name, target_url=url)
+        if file_path:
+            s3_file_path.append(file_path)
+
+        if not s3_file_path:
+            pass
+        else:
+            append_file_bronze_to_latest_version(
+                dataset_name=dataset_name, filter=season, s3_file_path=s3_file_path
+            )

--- a/asf_mission_data_tool/pipeline/public_attitudes_tracking_survey_pipeline/get_public_attitudes_tracking_survey_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/public_attitudes_tracking_survey_pipeline/get_public_attitudes_tracking_survey_to_bronze.py
@@ -1,7 +1,7 @@
 from asf_mission_data_tool.getters.data_getters import (
     save_to_s3_bronze,
     get_latest_version,
-    append_file_bronze_to_latest_version,
+    append_field_to_latest_version,
 )
 
 dataset_name = "public_attitudes_tracking_survey"
@@ -20,6 +20,9 @@ for season in ["Summer", "Spring", "Winter"]:
         if not s3_file_path:
             pass
         else:
-            append_file_bronze_to_latest_version(
-                dataset_name=dataset_name, filter=season, s3_file_path=s3_file_path
+            append_field_to_latest_version(
+                dataset_name=dataset_name,
+                filter=season,
+                s3_file_path=s3_file_path,
+                new_field_name="file_bronze",
             )

--- a/asf_mission_data_tool/pipeline/scottish_house_condition_survey_pipeline/get_scottish_house_condition_survey_pipeline.py
+++ b/asf_mission_data_tool/pipeline/scottish_house_condition_survey_pipeline/get_scottish_house_condition_survey_pipeline.py
@@ -1,0 +1,22 @@
+from asf_mission_data_tool.getters.data_getters import (
+    save_to_s3_bronze,
+    get_latest_version,
+    append_file_bronze_to_latest_version,
+)
+
+dataset_name = "scottish_house_condition_survey"
+
+latest_version = get_latest_version(dataset_name)
+
+s3_file_path = []
+for file_url in latest_version.get("file_url"):
+    file_path = save_to_s3_bronze(dataset_name=dataset_name, target_url=file_url)
+    if file_path:
+        s3_file_path.append(file_path)
+
+if not s3_file_path:
+    pass
+else:
+    append_file_bronze_to_latest_version(
+        dataset_name=dataset_name, s3_file_path=s3_file_path
+    )

--- a/asf_mission_data_tool/pipeline/scottish_house_condition_survey_pipeline/get_scottish_house_condition_survey_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/scottish_house_condition_survey_pipeline/get_scottish_house_condition_survey_to_bronze.py
@@ -1,7 +1,7 @@
 from asf_mission_data_tool.getters.data_getters import (
     save_to_s3_bronze,
     get_latest_version,
-    append_file_bronze_to_latest_version,
+    append_field_to_latest_version,
 )
 
 dataset_name = "scottish_house_condition_survey"
@@ -17,6 +17,8 @@ for file_url in latest_version.get("file_url"):
 if not s3_file_path:
     pass
 else:
-    append_file_bronze_to_latest_version(
-        dataset_name=dataset_name, s3_file_path=s3_file_path
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_bronze",
     )

--- a/asf_mission_data_tool/pipeline/seventh_carbon_budget_pipeline/get_seventh_carbon_budget_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/seventh_carbon_budget_pipeline/get_seventh_carbon_budget_to_bronze.py
@@ -1,0 +1,24 @@
+from asf_mission_data_tool.getters.data_getters import (
+    save_to_s3_bronze,
+    get_latest_version,
+    append_field_to_latest_version,
+)
+
+dataset_name = "seventh_carbon_budget"
+
+latest_version = get_latest_version(dataset_name)
+
+s3_file_path = []
+for file_url in latest_version.get("file_url"):
+    file_path = save_to_s3_bronze(dataset_name=dataset_name, target_url=file_url)
+    if file_path:
+        s3_file_path.append(file_path)
+
+if not s3_file_path:
+    pass
+else:
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_bronze",
+    )

--- a/asf_mission_data_tool/pipeline/sixth_carbon_budget_pipeline/get_sixth_carbon_budget_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/sixth_carbon_budget_pipeline/get_sixth_carbon_budget_to_bronze.py
@@ -1,0 +1,22 @@
+from asf_mission_data_tool.getters.data_getters import (
+    save_to_s3_bronze,
+    get_latest_version,
+    append_file_bronze_to_latest_version,
+)
+
+dataset_name = "sixth_carbon_budget"
+
+latest_version = get_latest_version(dataset_name)
+
+s3_file_path = []
+for file_url in latest_version.get("file_url"):
+    file_path = save_to_s3_bronze(dataset_name=dataset_name, target_url=file_url)
+    if file_path:
+        s3_file_path.append(file_path)
+
+if not s3_file_path:
+    pass
+else:
+    append_file_bronze_to_latest_version(
+        dataset_name=dataset_name, s3_file_path=s3_file_path
+    )

--- a/asf_mission_data_tool/pipeline/sixth_carbon_budget_pipeline/get_sixth_carbon_budget_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/sixth_carbon_budget_pipeline/get_sixth_carbon_budget_to_bronze.py
@@ -1,7 +1,7 @@
 from asf_mission_data_tool.getters.data_getters import (
     save_to_s3_bronze,
     get_latest_version,
-    append_file_bronze_to_latest_version,
+    append_field_to_latest_version,
 )
 
 dataset_name = "sixth_carbon_budget"
@@ -17,6 +17,8 @@ for file_url in latest_version.get("file_url"):
 if not s3_file_path:
     pass
 else:
-    append_file_bronze_to_latest_version(
-        dataset_name=dataset_name, s3_file_path=s3_file_path
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_bronze",
     )

--- a/asf_mission_data_tool/pipeline/uk_territorial_greenhouse_gas_emissions_statistics_pipeline/get_uk_territorial_greenhouse_gas_emissions_statistics_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/uk_territorial_greenhouse_gas_emissions_statistics_pipeline/get_uk_territorial_greenhouse_gas_emissions_statistics_to_bronze.py
@@ -1,0 +1,24 @@
+from asf_mission_data_tool.getters.data_getters import (
+    save_to_s3_bronze,
+    get_latest_version,
+    append_file_bronze_to_latest_version,
+)
+
+dataset_name = "uk_territorial_greenhouse_gas_emissions_statistics"
+
+latest_version = get_latest_version(dataset_name)
+
+s3_file_path = []
+for file_url in latest_version.get("file_url"):
+    file_path = save_to_s3_bronze(dataset_name=dataset_name, target_url=file_url)
+    if file_path:
+        s3_file_path.append(file_path)
+
+if not s3_file_path:
+    pass
+else:
+    append_file_bronze_to_latest_version(
+        dataset_name=dataset_name, s3_file_path=s3_file_path
+    )
+
+# Note: Might want to focus on the lastest *final* version, as the most recent is *provisional*

--- a/asf_mission_data_tool/pipeline/uk_territorial_greenhouse_gas_emissions_statistics_pipeline/get_uk_territorial_greenhouse_gas_emissions_statistics_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/uk_territorial_greenhouse_gas_emissions_statistics_pipeline/get_uk_territorial_greenhouse_gas_emissions_statistics_to_bronze.py
@@ -1,12 +1,12 @@
 from asf_mission_data_tool.getters.data_getters import (
     save_to_s3_bronze,
     get_latest_version,
-    append_file_bronze_to_latest_version,
+    append_field_to_latest_version,
 )
 
 dataset_name = "uk_territorial_greenhouse_gas_emissions_statistics"
 
-latest_version = get_latest_version(dataset_name)
+latest_version = get_latest_version(dataset_name, filter="final")
 
 s3_file_path = []
 for file_url in latest_version.get("file_url"):
@@ -17,8 +17,9 @@ for file_url in latest_version.get("file_url"):
 if not s3_file_path:
     pass
 else:
-    append_file_bronze_to_latest_version(
-        dataset_name=dataset_name, s3_file_path=s3_file_path
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        filter="final",
+        new_field_name="file_bronze",
     )
-
-# Note: Might want to focus on the lastest *final* version, as the most recent is *provisional*

--- a/asf_mission_data_tool/pipeline/welsh_housing_conditions_survey_pipeline/get_welsh_housing_conditions_survey_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/welsh_housing_conditions_survey_pipeline/get_welsh_housing_conditions_survey_to_bronze.py
@@ -1,0 +1,22 @@
+from asf_mission_data_tool.getters.data_getters import (
+    save_to_s3_bronze,
+    get_latest_version,
+    append_file_bronze_to_latest_version,
+)
+
+dataset_name = "welsh_housing_conditions_survey"
+
+latest_version = get_latest_version(dataset_name)
+
+s3_file_path = []
+for file_url in latest_version.get("file_url"):
+    file_path = save_to_s3_bronze(dataset_name=dataset_name, target_url=file_url)
+    if file_path:
+        s3_file_path.append(file_path)
+
+if not s3_file_path:
+    pass
+else:
+    append_file_bronze_to_latest_version(
+        dataset_name=dataset_name, s3_file_path=s3_file_path
+    )

--- a/asf_mission_data_tool/pipeline/welsh_housing_conditions_survey_pipeline/get_welsh_housing_conditions_survey_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/welsh_housing_conditions_survey_pipeline/get_welsh_housing_conditions_survey_to_bronze.py
@@ -1,7 +1,7 @@
 from asf_mission_data_tool.getters.data_getters import (
     save_to_s3_bronze,
     get_latest_version,
-    append_file_bronze_to_latest_version,
+    append_field_to_latest_version,
 )
 
 dataset_name = "welsh_housing_conditions_survey"
@@ -17,6 +17,8 @@ for file_url in latest_version.get("file_url"):
 if not s3_file_path:
     pass
 else:
-    append_file_bronze_to_latest_version(
-        dataset_name=dataset_name, s3_file_path=s3_file_path
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_bronze",
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+boto3
+toml


### PR DESCRIPTION
---

# Description

Addresses issue #1 

**Data getter functions**
This PR introduces a data getter function that extracts a file from its original source and uploads it to the designated s3 bucket. 

The following functions have been introduced in the `data_getters.py` module:

- `save_to_s3_bronze(dataset_name, target_url)`: This function makes a request for the target file, checks if it already exists in the s3 bucket (prompts user to confirm overwrite if it does exist) and uploads to s3. It returns the s3 path in which the main file was uploaded to.

- `_save_provenance_to_toml(func)`: Decorator for the main function `save_to_s3_bronze` in which provenance metadata is captured and uploaded in a .toml alongside the main file to s3. This decorator function also checks if a sidecar .toml for the main file already exists in the bucket, prompting for a separate user input to confirm overwrite. As discussed offline, I have left these overwrite prompts separate but would welcome any suggestions on how to combine them.

- `get_latest_version(dataset_name, filter)`: This function returns information about the latest version of a dataset from the `base.yaml` config file. For a given dataset, it identifies the latest version using the `release_date` field and returns all information about the latest version as a dictionary. Its primary use is to call the `file_url` of the latest dataset version.

- `append_file_bronze_to_latest_version(dataset_name, s3_file_path, filter)`: Updates the `base.yaml` config file with an additional `file_bronze` field to the latest version of the dataset. 

**Dataset information in config file**
Information on each dataset is stored in the `base.yaml` config file. The general structure (Note: I've enabled automatic sorting of keys by alphabetical order in the function `append_file_bronze_to_latest_version()`):
```
dataset:
  canonical_name_of_dataset:
    collection_url: https://...
    versions:
    - file_bronze:
        - s3://.../file_1
        - s3://.../file_2
      file_url:
        - https://.../file_1
        - https://.../file_2
      page_url: https://...
      release_date: YYYY-MM-DD
    - file_bronze:
        - s3://.../file_1
        - s3://.../file_2
      file_url:
        - https://.../file_1
        - https://.../file_2
      page_url: https://...
      release_date: YYYY-MM-DD  
```
Lists are used for:
- Multiple versions of a dataset (under `versions`)
- Multiple files in a dataset (under `file_url` and `file_bronze`). The order of files across these two fields are currently ensured in a semi-manual way as the `file_bronze` list is populated via looping through each item in the `file_url` list.

**Extraction stage scripts for each shortlisted dataset**
In the pipeline folder, there are child folders for 12 datasets each containing `get_[dataset]_to_bronze.py`. Running this file for a dataset calls the latest version, moves the file(s) to s3 and appends the config file with the s3 destination path.

All follow a similar structure, except for the Public Attitudes Tracking Survey dataset where the `filter` argument needs to be used to upload the latest version of each season (summer, spring, winter). 


# Instructions for Reviewer

For this PR, please review the data getters module and their usage, checking for any bugs, missing documentation and opportunities for improvement.

Please also check that running the `get_[dataset]_to_bronze.py` scripts produce the expected output in terms of what is uploaded to the s3 bucket and also asking for user input in the correct circumstances to overwrite/abort upload. 

# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
