### PR TITLE
2 etl flow from bronze to silver

### DIFF
--- a/asf_mission_data_tool/config/base.yaml
+++ b/asf_mission_data_tool/config/base.yaml
@@ -1,0 +1,165 @@
+dataset:
+  energy_consumption_in_the_uk:
+    collection_url: https://www.gov.uk/government/collections/energy-consumption-in-the-uk
+    versions:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/energy_consumption_in_the_uk/ECUK_2024_Consumption_tables.xlsx
+          - s3://asf-mission-data-tool/bronze/energy_consumption_in_the_uk/ECUK_2024_Intensity_tables.xlsx
+          - s3://asf-mission-data-tool/bronze/energy_consumption_in_the_uk/ECUK_2024_Primary_Energy_tables.xlsx
+          - s3://asf-mission-data-tool/bronze/energy_consumption_in_the_uk/ECUK_2024_End_Use_tables.xlsx
+          - s3://asf-mission-data-tool/bronze/energy_consumption_in_the_uk/ECUK_2024_Electrical_Products_tables.xlsx
+        file_url:
+          - https://assets.publishing.service.gov.uk/media/66f132604f35b65bf4cffe98/ECUK_2024_Consumption_tables.xlsx
+          - https://assets.publishing.service.gov.uk/media/66f1327d02970476b261ab04/ECUK_2024_Intensity_tables.xlsx
+          - https://assets.publishing.service.gov.uk/media/66f1329802970476b261ab05/ECUK_2024_Primary_Energy_tables.xlsx
+          - https://assets.publishing.service.gov.uk/media/66f132b1b4d70bfba161ab06/ECUK_2024_End_Use_tables.xlsx
+          - https://assets.publishing.service.gov.uk/media/66f132cec9bf1d4e84379f94/ECUK_2024_Electrical_Products_tables.xlsx
+        page_url: https://www.gov.uk/government/statistics/energy-consumption-in-the-uk-2024
+        release_date: "2024-09-26"
+  energy_performance_of_buildings_certificates:
+    collection_url: https://www.gov.uk/government/collections/energy-performance-of-buildings-certificates
+    versions:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/energy_performance_of_buildings_certificates/A1-_All_Properties.ods
+          - s3://asf-mission-data-tool/bronze/energy_performance_of_buildings_certificates/D1-_Domestic_Properties.ods
+          - s3://asf-mission-data-tool/bronze/energy_performance_of_buildings_certificates/D2-_Domestic_Properties.ods
+          - s3://asf-mission-data-tool/bronze/energy_performance_of_buildings_certificates/D3-_Domestic_Properties.ods
+          - s3://asf-mission-data-tool/bronze/energy_performance_of_buildings_certificates/D4A-_Domestic_Properties.ods
+          - s3://asf-mission-data-tool/bronze/energy_performance_of_buildings_certificates/D4B-_Domestic_Properties.ods
+        file_url:
+          - https://assets.publishing.service.gov.uk/media/6717644696def6d27a4c9b6e/A1-_All_Properties.ods
+          - https://assets.publishing.service.gov.uk/media/67176490720eec5582849bad/D1-_Domestic_Properties.ods
+          - https://assets.publishing.service.gov.uk/media/671765a99242eecc6c849bb4/D2-_Domestic_Properties.ods
+          - https://assets.publishing.service.gov.uk/media/671765924a6b12291ed99875/D3-_Domestic_Properties.ods
+          - https://assets.publishing.service.gov.uk/media/671765c4583ef2380ad99880/D4A-_Domestic_Properties.ods
+          - https://assets.publishing.service.gov.uk/media/67176653d100972c0f4c9b64/D4B-_Domestic_Properties.ods
+        page_url: https://www.gov.uk/government/statistical-data-sets/live-tables-on-energy-performance-of-buildings-certificates
+        release_date: "2024-10-24"
+  energy_price_cap_levels:
+    collection_url: https://www.ofgem.gov.uk/energy-policy-and-regulation/policy-and-regulatory-programmes/energy-price-cap-default-tariff-policy/energy-price-cap-default-tariff-levels
+    versions:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/energy_price_cap_levels/Annex_9_-_Levelisation_allowance_methodology_and_levelised_cap_levels_v1.4.xlsx
+        file_url:
+          - https://www.ofgem.gov.uk/sites/default/files/2024-11/Annex_9_-_Levelisation_allowance_methodology_and_levelised_cap_levels_v1.4.xlsx
+        page_url: https://www.ofgem.gov.uk/energy-policy-and-regulation/policy-and-regulatory-programmes/energy-price-cap-default-tariff-policy/energy-price-cap-default-tariff-levels
+        release_date: "2024-11-22"
+  fuel_poverty_statistics:
+    collection_url: https://www.gov.uk/government/collections/fuel-poverty-statistics
+    versions:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/fuel_poverty_statistics/2023-fuel-poverty-detailed-tables-xls.xlsx
+        file_url:
+          - https://assets.publishing.service.gov.uk/media/65cca543130549000c8679b9/2023-fuel-poverty-detailed-tables-xls.xlsx
+        page_url: https://www.gov.uk/government/statistics/fuel-poverty-detailed-tables-2024-2023-data
+        release_date: "2024-02-15"
+  future_energy_scenarios:
+    collection_url: https://www.neso.energy/publications/future-energy-scenarios-fes
+    versions:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/future_energy_scenarios/Future Energy Scenarios
+            2024 Data Workbook_V003.xlsx
+        file_url:
+          - https://www.neso.energy/fes-data-workbook-2024
+        page_url: https://www.neso.energy/publications/future-energy-scenarios-fes
+        release_date: "2024-07-15"
+  heat_pump_deployment_quarterly_statistics:
+    collection_url: https://www.gov.uk/government/collections/heat-pump-deployment-statistics
+    versions:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/heat_pump_deployment_quarterly_statistics/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2024_Q3.xlsx
+        file_url:
+          - https://assets.publishing.service.gov.uk/media/674ddaf51916486d54daf085/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2024_Q3.xlsx
+        page_url: https://www.gov.uk/government/statistics/heat-pump-deployment-statistics-september-2024
+        release_date: "2024-12-05"
+      - file_url: https://assets.publishing.service.gov.uk/media/66f53fee080bdf716392e93f/Heat_pump_deployment_quarterly_statistics_United_Kingdom_June_2024.xlsx
+        page_url: https://www.gov.uk/government/statistics/heat-pump-deployment-statistics-june-2024
+        release_date: "2024-09-26"
+  northern_ireland_statistics_and_research_agency_census:
+    collection_url: https://www.nisra.gov.uk/statistics/census
+    versions:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/northern_ireland_statistics_and_research_agency_census/census-2021-commissioned-table-ct0082.xlsx
+        file_url:
+          - https://www.nisra.gov.uk/system/files/statistics/census-2021-commissioned-table-ct0082.xlsx
+        page_url: https://www.nisra.gov.uk/publications/census-2021-commissioned-table-ct0082
+        release_date: "2024-02-12"
+  public_attitudes_tracking_survey:
+    collection_url: https://www.gov.uk/government/collections/public-attitudes-tracking-survey
+    versions:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/public_attitudes_tracking_survey/DESNZ_PAT_Summer_2024_Time_Series.xlsx
+          - s3://asf-mission-data-tool/bronze/public_attitudes_tracking_survey/DESNZ_PAT_Summer_2024_Crosstabulations.xlsx
+        file_url:
+          - https://assets.publishing.service.gov.uk/media/671a182f593bb124be9c13dc/DESNZ_PAT_Summer_2024_Time_Series.xlsx
+          - https://assets.publishing.service.gov.uk/media/671a181a593bb124be9c13db/DESNZ_PAT_Summer_2024_Crosstabulations.xlsx
+        page_url: https://www.gov.uk/government/statistics/desnz-public-attitudes-tracker-summer-2024
+        release_date: "2024-10-29"
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/public_attitudes_tracking_survey/DESNZ_PAT_Spring_2024_Time_series.xlsx
+          - s3://asf-mission-data-tool/bronze/public_attitudes_tracking_survey/DESNZ_PAT__Spring_2024__Crosstabulations.xlsx
+        file_url:
+          - https://assets.publishing.service.gov.uk/media/6682749697ea0c79abfe4dc0/DESNZ_PAT_Spring_2024_Time_series.xlsx
+          - https://assets.publishing.service.gov.uk/media/668274ab7d26b2be17a4b4c1/DESNZ_PAT__Spring_2024__Crosstabulations.xlsx
+        page_url: https://www.gov.uk/government/statistics/desnz-public-attitudes-tracker-spring-2024
+        release_date: "2024-07-03"
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/public_attitudes_tracking_survey/DESNZ_Public_Attitudes_Tracker_Winter_2023_Time_Series.xlsx
+          - s3://asf-mission-data-tool/bronze/public_attitudes_tracking_survey/DESNZ_Public_Attitudes_Tracker_Winter_2023_Crosstabulations__Revised_July_2024_.xlsx
+        file_url:
+          - https://assets.publishing.service.gov.uk/media/65e88e6062ff48001a87b2b2/DESNZ_Public_Attitudes_Tracker_Winter_2023_Time_Series.xlsx
+          - https://assets.publishing.service.gov.uk/media/66829a4e7d26b2be17a4b4f2/DESNZ_Public_Attitudes_Tracker_Winter_2023_Crosstabulations__Revised_July_2024_.xlsx
+        page_url: https://www.gov.uk/government/statistics/desnz-public-attitudes-tracker-winter-2023
+        release_date: "2024-03-07"
+  scottish_house_condition_survey:
+    collection_url: https://www.gov.scot/collections/scottish-house-condition-survey/
+    versions:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/scottish_house_condition_survey/SHCS%2B2023-%2BChapter%2B01%2BKey%2BAttributes%2Bof%2Bthe%2BScottish%2BHousing%2BStock%2B%25E2%2580%2593%2Btables%2Band%2Bfigures.ods
+          - s3://asf-mission-data-tool/bronze/scottish_house_condition_survey/SHCS%2B2023-%2BChapter%2B02%2BEnergy%2BEfficiency-%2Btables%2Band%2Bfigures.ods
+          - s3://asf-mission-data-tool/bronze/scottish_house_condition_survey/SHCS%2B2023-%2BChapter%2B03%2BFuel%2BPoverty-%2Btables%2Band%2Bfigures.ods
+          - s3://asf-mission-data-tool/bronze/scottish_house_condition_survey/SHCS%2B2023-%2BChapter%2B04%2BEnergy%2BPerceptions-%2Btables%2Band%2Bfigures.ods
+          - s3://asf-mission-data-tool/bronze/scottish_house_condition_survey/SHCS%2B2023-%2BChapter%2B05%2BHousing%2BConditions%2B-%2Btables%2Band%2Bfigures.ods
+          - s3://asf-mission-data-tool/bronze/scottish_house_condition_survey/SHCS%2B2023-%2BChapter%2B06%2BBedroom%2BStandard-%2Btables%2Band%2Bfigures.ods
+        file_url:
+          - https://www.gov.scot/binaries/content/documents/govscot/publications/statistics/2025/01/scottish-house-condition-survey-2023-key-findings/documents/shcs-2023--chapter-01-key-attributes-of-the-scottish-housing-stock---tables-and-figures/shcs-2023--chapter-01-key-attributes-of-the-scottish-housing-stock---tables-and-figures/govscot%3Adocument/SHCS%2B2023-%2BChapter%2B01%2BKey%2BAttributes%2Bof%2Bthe%2BScottish%2BHousing%2BStock%2B%25E2%2580%2593%2Btables%2Band%2Bfigures.ods
+          - https://www.gov.scot/binaries/content/documents/govscot/publications/statistics/2025/01/scottish-house-condition-survey-2023-key-findings/documents/shcs-2023-chapter-02-energy-efficiency--tables-and-figures/shcs-2023-chapter-02-energy-efficiency--tables-and-figures/govscot%3Adocument/SHCS%2B2023-%2BChapter%2B02%2BEnergy%2BEfficiency-%2Btables%2Band%2Bfigures.ods
+          - https://www.gov.scot/binaries/content/documents/govscot/publications/statistics/2025/01/scottish-house-condition-survey-2023-key-findings/documents/shcs-2023--chapter-03-fuel-poverty--tables-and-figures/shcs-2023--chapter-03-fuel-poverty--tables-and-figures/govscot%3Adocument/SHCS%2B2023-%2BChapter%2B03%2BFuel%2BPoverty-%2Btables%2Band%2Bfigures.ods
+          - https://www.gov.scot/binaries/content/documents/govscot/publications/statistics/2025/01/scottish-house-condition-survey-2023-key-findings/documents/shcs-2023--chapter-04-energy-perceptions--tables-and-figures/shcs-2023--chapter-04-energy-perceptions--tables-and-figures/govscot%3Adocument/SHCS%2B2023-%2BChapter%2B04%2BEnergy%2BPerceptions-%2Btables%2Band%2Bfigures.ods
+          - https://www.gov.scot/binaries/content/documents/govscot/publications/statistics/2025/01/scottish-house-condition-survey-2023-key-findings/documents/shcs-2023--chapter-05-housing-conditions---tables-and-figures/shcs-2023--chapter-05-housing-conditions---tables-and-figures/govscot%3Adocument/SHCS%2B2023-%2BChapter%2B05%2BHousing%2BConditions%2B-%2Btables%2Band%2Bfigures.ods
+          - https://www.gov.scot/binaries/content/documents/govscot/publications/statistics/2025/01/scottish-house-condition-survey-2023-key-findings/documents/shcs-2023--chapter-06-bedroom-standard--tables-and-figures/shcs-2023--chapter-06-bedroom-standard--tables-and-figures/govscot%3Adocument/SHCS%2B2023-%2BChapter%2B06%2BBedroom%2BStandard-%2Btables%2Band%2Bfigures.ods
+        page_url: https://www.gov.scot/publications/scottish-house-condition-survey-2023-key-findings/documents/
+        release_date: "2025-01-28"
+  sixth_carbon_budget:
+    collection_url: https://www.theccc.org.uk/publication/sixth-carbon-budget/
+    versions:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/sixth_carbon_budget/The-Sixth-Carbon-Budget-Dataset_v2.xlsx
+        file_url:
+          - https://www.theccc.org.uk/wp-content/uploads/2020/12/The-Sixth-Carbon-Budget-Dataset_v2.xlsx
+        page_url: https://www.theccc.org.uk/publication/sixth-carbon-budget/#supporting-information-charts-and-data
+        release_date: "2020-12-09"
+  uk_territorial_greenhouse_gas_emissions_statistics:
+    collection_url: https://www.gov.uk/government/collections/uk-territorial-greenhouse-gas-emissions-statistics
+    versions:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/uk_territorial_greenhouse_gas_emissions_statistics/2023-provisional-emissions-data-tables.xlsx
+        file_url:
+          - https://assets.publishing.service.gov.uk/media/660305b1c34a860011be75f2/2023-provisional-emissions-data-tables.xlsx
+        page_url: https://www.gov.uk/government/statistics/provisional-uk-greenhouse-gas-emissions-national-statistics-2023
+        release_date: "2024-03-28"
+      - file_url:
+          - https://assets.publishing.service.gov.uk/media/65ff114a65ca2ffef17da7a6/final-greenhouse-gas-emissions-tables-2022.xlsx
+          - https://assets.publishing.service.gov.uk/media/66044b8cf9ab410011eea42d/final-greenhouse-gas-emissions-end-user-tables-2022.xlsx
+          - https://assets.publishing.service.gov.uk/media/667bec4297ea0c79abfe4c72/sic-final-greenhouse-gas-emissions-tables-2022.xlsx
+        page_url: https://www.gov.uk/government/statistics/final-uk-greenhouse-gas-emissions-national-statistics-1990-to-2022
+        release_date: "2024-02-06"
+  welsh_housing_conditions_survey:
+    collection_url: https://www.gov.wales/welsh-housing-conditions-survey
+    versions:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/welsh_housing_conditions_survey/welsh-housing-conditions-survey-results-viewer-2017-18-en.ods
+        file_url:
+          - https://www.gov.wales/sites/default/files/statistics-and-research/2019-11/welsh-housing-conditions-survey-results-viewer-2017-18-en.ods
+        page_url: https://www.gov.wales/welsh-housing-conditions-survey-results-viewer
+        release_date: "2018-12-20"

--- a/asf_mission_data_tool/config/base.yaml
+++ b/asf_mission_data_tool/config/base.yaml
@@ -40,10 +40,38 @@ dataset:
     versions:
       - file_bronze:
           - s3://asf-mission-data-tool/bronze/energy_price_cap_levels/Annex_9_-_Levelisation_allowance_methodology_and_levelised_cap_levels_v1.4.xlsx
+        file_silver:
+          - s3://asf-mission-data-tool/silver/energy_price_cap_levels/November_2024/Annex_9_-_Levelisation_allowance_methodology_and_levelised_cap_levels_v1.4_1c_Consumption_adjusted_levels.parquet
         file_url:
           - https://www.ofgem.gov.uk/sites/default/files/2024-11/Annex_9_-_Levelisation_allowance_methodology_and_levelised_cap_levels_v1.4.xlsx
         page_url: https://www.ofgem.gov.uk/energy-policy-and-regulation/policy-and-regulatory-programmes/energy-price-cap-default-tariff-policy/energy-price-cap-default-tariff-levels
         release_date: "2024-11-22"
+        tables:
+          - dtypes:
+              Consumption: str
+              Fuel: str
+              Payment method: str
+              Price cap period: str
+              Tariff component: str
+              value: float
+            sheet_name: 1c Consumption adjusted levels
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/energy_price_cap_levels/Annex-9-Levelisation-allowance-methodology-and-levelised-cap-levels-v1.5.xlsx
+        file_silver:
+          - s3://asf-mission-data-tool/silver/energy_price_cap_levels/February_2025/Annex-9-Levelisation-allowance-methodology-and-levelised-cap-levels-v1.5_1c_Consumption_adjusted_levels.parquet
+        file_url:
+          - https://www.ofgem.gov.uk/sites/default/files/2025-02/Annex-9-Levelisation-allowance-methodology-and-levelised-cap-levels-v1.5.xlsx
+        page_url: https://www.ofgem.gov.uk/energy-policy-and-regulation/policy-and-regulatory-programmes/energy-price-cap-default-tariff-policy/energy-price-cap-default-tariff-levels
+        release_date: "2025-02-25"
+        tables:
+          - dtypes:
+              Consumption: str
+              Fuel: str
+              Payment method: str
+              Price cap period: str
+              Tariff component: str
+              value: float
+            sheet_name: 1c Consumption adjusted levels
   fuel_poverty_statistics:
     collection_url: https://www.gov.uk/government/collections/fuel-poverty-statistics
     versions:
@@ -58,7 +86,7 @@ dataset:
     versions:
       - file_bronze:
           - s3://asf-mission-data-tool/bronze/future_energy_scenarios/Future Energy Scenarios
-            2024 Data Workbook_V003.xlsx
+            2024 Data Workbook_V005.xlsx
         file_url:
           - https://www.neso.energy/fes-data-workbook-2024
         page_url: https://www.neso.energy/publications/future-energy-scenarios-fes
@@ -68,10 +96,55 @@ dataset:
     versions:
       - file_bronze:
           - s3://asf-mission-data-tool/bronze/heat_pump_deployment_quarterly_statistics/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2024_Q3.xlsx
+        file_silver:
+          - s3://asf-mission-data-tool/silver/heat_pump_deployment_quarterly_statistics/December_2024/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2024_Q3_Table_1_1.parquet
+          - s3://asf-mission-data-tool/silver/heat_pump_deployment_quarterly_statistics/December_2024/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2024_Q3_Table_1_2.parquet
+          - s3://asf-mission-data-tool/silver/heat_pump_deployment_quarterly_statistics/December_2024/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2024_Q3_Table_1_3.parquet
         file_url:
           - https://assets.publishing.service.gov.uk/media/674ddaf51916486d54daf085/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2024_Q3.xlsx
         page_url: https://www.gov.uk/government/statistics/heat-pump-deployment-statistics-september-2024
         release_date: "2024-12-05"
+        tables:
+          - dtypes:
+              All schemes: int
+              Boiler Upgrade Scheme[Note 5]: int
+              Domestic Renewable Heat Incentive[note 11]: int
+              Energy Company Obligation[Note 10]: int
+              Green Homes Grant Voucher Scheme[Note 8]: int
+              Home Upgrade Grant[Note 6]: int
+              Installation quarter [note 4]: str
+              Local Authority Delivery[note 7]: int
+              Non-Domestic Renewable Heat Incentive[Note 12]: int
+              Social Housing Decarbonisation Fund[Note 9]: int
+            sheet_name: Table 1.1
+            skiprows: 5
+          - dtypes:
+              Air source heat pumps [note 13]: int
+              All technologies: int
+              Ground/water source heat pumps [note 13]: int
+              Installation quarter [note 4]: str
+              Unknown technology [note 14]: int
+            sheet_name: Table 1.2
+            skiprows: 5
+          - dtypes:
+              East: int
+              East Midlands: int
+              England: int
+              England and Wales: int
+              Installation quarter [note 4]: str
+              London: int
+              North East: int
+              North West: int
+              Northern Ireland: int
+              Scotland: int
+              South East: int
+              South West: int
+              United Kingdom: int
+              Wales: int
+              West Midlands: int
+              Yorkshire and The Humber: int
+            sheet_name: Table 1.3
+            skiprows: 9
       - file_url: https://assets.publishing.service.gov.uk/media/66f53fee080bdf716392e93f/Heat_pump_deployment_quarterly_statistics_United_Kingdom_June_2024.xlsx
         page_url: https://www.gov.uk/government/statistics/heat-pump-deployment-statistics-june-2024
         release_date: "2024-09-26"
@@ -148,21 +221,153 @@ dataset:
           - https://www.theccc.org.uk/wp-content/uploads/2020/12/The-Sixth-Carbon-Budget-Dataset_v2.xlsx
         page_url: https://www.theccc.org.uk/publication/sixth-carbon-budget/#supporting-information-charts-and-data
         release_date: "2020-12-09"
+        tables:
+          - sheet_name: Buildings additional data
+            skipcols: 1
+            skiprows: 38
+          - dtypes:
+              Metric index: str
+              Scenario: str
+              Region: str
+              Sector: str
+              Amalgamation: str
+              Metric: str
+              Units: str
+              2020: float
+              2021: float
+              2022: float
+              2023: float
+              2024: float
+              2025: float
+              2026: float
+              2027: float
+              2028: float
+              2029: float
+              2030: float
+              2031: float
+              2032: float
+              2033: float
+              2034: float
+              2035: float
+              2036: float
+              2037: float
+              2038: float
+              2039: float
+              2040: float
+              2041: float
+              2042: float
+              2043: float
+              2044: float
+              2045: float
+              2046: float
+              2047: float
+              2048: float
+              2049: float
+              2050: float
+            sheet_name: Raw data
+            skipcols: 1
+            skiprows: 1
   uk_territorial_greenhouse_gas_emissions_statistics:
     collection_url: https://www.gov.uk/government/collections/uk-territorial-greenhouse-gas-emissions-statistics
     versions:
-      - file_bronze:
-          - s3://asf-mission-data-tool/bronze/uk_territorial_greenhouse_gas_emissions_statistics/2023-provisional-emissions-data-tables.xlsx
-        file_url:
+      - file_url:
           - https://assets.publishing.service.gov.uk/media/660305b1c34a860011be75f2/2023-provisional-emissions-data-tables.xlsx
         page_url: https://www.gov.uk/government/statistics/provisional-uk-greenhouse-gas-emissions-national-statistics-2023
         release_date: "2024-03-28"
-      - file_url:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/uk_territorial_greenhouse_gas_emissions_statistics/final-greenhouse-gas-emissions-tables-2022.xlsx
+          - s3://asf-mission-data-tool/bronze/uk_territorial_greenhouse_gas_emissions_statistics/final-greenhouse-gas-emissions-end-user-tables-2022.xlsx
+          - s3://asf-mission-data-tool/bronze/uk_territorial_greenhouse_gas_emissions_statistics/sic-final-greenhouse-gas-emissions-tables-2022.xlsx
+        file_silver:
+          - s3://asf-mission-data-tool/silver/uk_territorial_greenhouse_gas_emissions_statistics/February_2024/final-greenhouse-gas-emissions-tables-2022_1_2.parquet
+          - s3://asf-mission-data-tool/silver/uk_territorial_greenhouse_gas_emissions_statistics/February_2024/final-greenhouse-gas-emissions-tables-2022_7_1.parquet
+        file_url:
           - https://assets.publishing.service.gov.uk/media/65ff114a65ca2ffef17da7a6/final-greenhouse-gas-emissions-tables-2022.xlsx
           - https://assets.publishing.service.gov.uk/media/66044b8cf9ab410011eea42d/final-greenhouse-gas-emissions-end-user-tables-2022.xlsx
           - https://assets.publishing.service.gov.uk/media/667bec4297ea0c79abfe4c72/sic-final-greenhouse-gas-emissions-tables-2022.xlsx
         page_url: https://www.gov.uk/government/statistics/final-uk-greenhouse-gas-emissions-national-statistics-1990-to-2022
         release_date: "2024-02-06"
+        tables:
+          - dtypes:
+              "1990": float
+              "1991": float
+              "1992": float
+              "1993": float
+              "1994": float
+              "1995": float
+              "1996": float
+              "1997": float
+              "1998": float
+              "1999": float
+              "2000": float
+              "2001": float
+              "2002": float
+              "2003": float
+              "2004": float
+              "2005": float
+              "2006": float
+              "2007": float
+              "2008": float
+              "2009": float
+              "2010": float
+              "2011": float
+              "2012": float
+              "2013": float
+              "2014": float
+              "2015": float
+              "2016": float
+              "2017": float
+              "2018": float
+              "2019": float
+              "2020": float
+              "2021": float
+              "2022": float
+              TES Category: str
+              TES Sector: str
+              TES Subsector: str
+            file_url: https://assets.publishing.service.gov.uk/media/65ff114a65ca2ffef17da7a6/final-greenhouse-gas-emissions-tables-2022.xlsx
+            sheet_name: "1.2"
+            skiprows: 6
+          - dtypes:
+              "1990": float
+              "1991": float
+              "1992": float
+              "1993": float
+              "1994": float
+              "1995": float
+              "1996": float
+              "1997": float
+              "1998": float
+              "1999": float
+              "2000": float
+              "2001": float
+              "2002": float
+              "2003": float
+              "2004": float
+              "2005": float
+              "2006": float
+              "2007": float
+              "2008": float
+              "2009": float
+              "2010": float
+              "2011": float
+              "2012": float
+              "2013": float
+              "2014": float
+              "2015": float
+              "2016": float
+              "2017": float
+              "2018": float
+              "2019": float
+              "2020": float
+              "2021": float
+              "2022": float
+              TES Category: str
+              TES Sector: str
+              TES Subsector: str
+            file_url: https://assets.publishing.service.gov.uk/media/66044b8cf9ab410011eea42d/final-greenhouse-gas-emissions-end-user-tables-2022.xlsx
+            sheet_name: "7.1"
+            skiprows: 6
   welsh_housing_conditions_survey:
     collection_url: https://www.gov.wales/welsh-housing-conditions-survey
     versions:

--- a/asf_mission_data_tool/config/base.yaml
+++ b/asf_mission_data_tool/config/base.yaml
@@ -694,6 +694,25 @@ dataset:
               variable_type: str
               wave_season: str
               wave_year: int64
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/public_attitudes_tracking_survey/DESNZ_Public_Attitudes_Tracker_-_Time_series__Summer_2025__UK.xlsx
+          - s3://asf-mission-data-tool/bronze/public_attitudes_tracking_survey/DESNZ_Public_Attitudes_Tracker_-_Crosstabulations__Summer_2025__UK.xlsx
+        file_silver: s3://asf-mission-data-tool/silver/public_attitudes_tracking_survey/October_2025/DESNZ_Public_Attitudes_Tracker_-_Time_series__Summer_2025__UK_all_questions.parquet
+        file_url:
+          - https://assets.publishing.service.gov.uk/media/68fa3e9b30c331c88be6f044/DESNZ_Public_Attitudes_Tracker_-_Time_series__Summer_2025__UK.xlsx
+          - https://assets.publishing.service.gov.uk/media/68fa3e8830c331c88be6f043/DESNZ_Public_Attitudes_Tracker_-_Crosstabulations__Summer_2025__UK.xlsx
+        page_url: https://www.gov.uk/government/statistics/desnz-public-attitudes-tracker-summer-2025
+        release_date: "2025-10-28"
+        tables:
+          - dtypes:
+              question: str
+              season_end_date: datetime64[ns]
+              season_start_date: datetime64[ns]
+              value: float64
+              variable: str
+              variable_type: str
+              wave_season: str
+              wave_year: int64
   scottish_house_condition_survey:
     collection_url: https://www.gov.scot/collections/scottish-house-condition-survey/
     versions:

--- a/asf_mission_data_tool/config/base.yaml
+++ b/asf_mission_data_tool/config/base.yaml
@@ -8,6 +8,9 @@ dataset:
           - s3://asf-mission-data-tool/bronze/energy_consumption_in_the_uk/ECUK_2024_Primary_Energy_tables.xlsx
           - s3://asf-mission-data-tool/bronze/energy_consumption_in_the_uk/ECUK_2024_End_Use_tables.xlsx
           - s3://asf-mission-data-tool/bronze/energy_consumption_in_the_uk/ECUK_2024_Electrical_Products_tables.xlsx
+        file_silver:
+          - s3://asf-mission-data-tool/silver/energy_consumption_in_the_uk/September_2024/ECUK_2024_Consumption_tables_Table_C1.parquet
+          - s3://asf-mission-data-tool/silver/energy_consumption_in_the_uk/September_2024/ECUK_2024_Consumption_tables_Table_C9.parquet
         file_url:
           - https://assets.publishing.service.gov.uk/media/66f132604f35b65bf4cffe98/ECUK_2024_Consumption_tables.xlsx
           - https://assets.publishing.service.gov.uk/media/66f1327d02970476b261ab04/ECUK_2024_Intensity_tables.xlsx
@@ -16,6 +19,23 @@ dataset:
           - https://assets.publishing.service.gov.uk/media/66f132cec9bf1d4e84379f94/ECUK_2024_Electrical_Products_tables.xlsx
         page_url: https://www.gov.uk/government/statistics/energy-consumption-in-the-uk-2024
         release_date: "2024-09-26"
+        tables:
+          - dtypes:
+              category: str
+              energy_consumption_ktoe: float
+              sector: str
+              year: int
+            file_url: https://assets.publishing.service.gov.uk/media/66f132604f35b65bf4cffe98/ECUK_2024_Consumption_tables.xlsx
+            sheet_name: Table C1
+            skiprows: 4
+          - dtypes:
+              fuel: str
+              value: float
+              variable: str
+              year: int
+            file_url: https://assets.publishing.service.gov.uk/media/66f132604f35b65bf4cffe98/ECUK_2024_Consumption_tables.xlsx
+            sheet_name: Table C9
+            skiprows: 3
   energy_performance_of_buildings_certificates:
     collection_url: https://www.gov.uk/government/collections/energy-performance-of-buildings-certificates
     versions:
@@ -26,6 +46,13 @@ dataset:
           - s3://asf-mission-data-tool/bronze/energy_performance_of_buildings_certificates/D3-_Domestic_Properties.ods
           - s3://asf-mission-data-tool/bronze/energy_performance_of_buildings_certificates/D4A-_Domestic_Properties.ods
           - s3://asf-mission-data-tool/bronze/energy_performance_of_buildings_certificates/D4B-_Domestic_Properties.ods
+        file_silver:
+          - s3://asf-mission-data-tool/silver/energy_performance_of_buildings_certificates/January_2025/D1-_Domestic_Properties_D1_England_Only.parquet
+          - s3://asf-mission-data-tool/silver/energy_performance_of_buildings_certificates/January_2025/D1-_Domestic_Properties_D1_Wales_Only.parquet
+          - s3://asf-mission-data-tool/silver/energy_performance_of_buildings_certificates/January_2025/D2-_Domestic_Properties_D2_England_Only.parquet
+          - s3://asf-mission-data-tool/silver/energy_performance_of_buildings_certificates/January_2025/D2-_Domestic_Properties_D2_Wales_Only.parquet
+          - s3://asf-mission-data-tool/silver/energy_performance_of_buildings_certificates/January_2025/D3-_Domestic_Properties_D3_England_Only.parquet
+          - s3://asf-mission-data-tool/silver/energy_performance_of_buildings_certificates/January_2025/D3-_Domestic_Properties_D3_Wales_Only.parquet
         file_url:
           - https://assets.publishing.service.gov.uk/media/6717644696def6d27a4c9b6e/A1-_All_Properties.ods
           - https://assets.publishing.service.gov.uk/media/67176490720eec5582849bad/D1-_Domestic_Properties.ods
@@ -34,7 +61,56 @@ dataset:
           - https://assets.publishing.service.gov.uk/media/671765c4583ef2380ad99880/D4A-_Domestic_Properties.ods
           - https://assets.publishing.service.gov.uk/media/67176653d100972c0f4c9b64/D4B-_Domestic_Properties.ods
         page_url: https://www.gov.uk/government/statistical-data-sets/live-tables-on-energy-performance-of-buildings-certificates
-        release_date: "2024-10-24"
+        release_date: "2025-01-30"
+        tables:
+          - dtypes:
+              Quarter: int64
+              Value: int64
+              Variable: str
+              Year: int64
+            file_url: https://assets.publishing.service.gov.uk/media/67176490720eec5582849bad/D1-_Domestic_Properties.ods
+            sheet_name: D1_England_Only
+            skiprows: 3
+          - dtypes:
+              Quarter: int64
+              Value: int64
+              Variable: str
+              Year: int64
+            file_url: https://assets.publishing.service.gov.uk/media/67176490720eec5582849bad/D1-_Domestic_Properties.ods
+            sheet_name: D1_Wales_Only
+            skiprows: 3
+          - dtypes:
+              Quarter: int64
+              Value: int64
+              Variable: str
+              Year: int64
+            file_url: https://assets.publishing.service.gov.uk/media/671765a99242eecc6c849bb4/D2-_Domestic_Properties.ods
+            sheet_name: D2_England_Only
+            skiprows: 3
+          - dtypes:
+              Quarter: int64
+              Value: int64
+              Variable: str
+              Year: int64
+            file_url: https://assets.publishing.service.gov.uk/media/671765a99242eecc6c849bb4/D2-_Domestic_Properties.ods
+            sheet_name: D2_Wales_Only
+            skiprows: 3
+          - dtypes:
+              Quarter: int64
+              Value: int64
+              Variable: str
+              Year: int64
+            file_url: https://assets.publishing.service.gov.uk/media/671765924a6b12291ed99875/D3-_Domestic_Properties.ods
+            sheet_name: D3_England_Only
+            skiprows: 3
+          - dtypes:
+              Quarter: int64
+              Value: int64
+              Variable: str
+              Year: int64
+            file_url: https://assets.publishing.service.gov.uk/media/671765924a6b12291ed99875/D3-_Domestic_Properties.ods
+            sheet_name: D3_Wales_Only
+            skiprows: 3
   energy_price_cap_levels:
     collection_url: https://www.ofgem.gov.uk/energy-policy-and-regulation/policy-and-regulatory-programmes/energy-price-cap-default-tariff-policy/energy-price-cap-default-tariff-levels
     versions:
@@ -48,11 +124,13 @@ dataset:
         release_date: "2024-11-22"
         tables:
           - dtypes:
-              Consumption: str
-              Fuel: str
-              Payment method: str
-              Price cap period: str
-              Tariff component: str
+              consumption: str
+              fuel: str
+              payment_method: str
+              price_cap_period: str
+              price_cap_period_end: datetime64[ns]
+              price_cap_period_start: datetime64[ns]
+              tariff_component: str
               value: float
             sheet_name: 1c Consumption adjusted levels
       - file_bronze:
@@ -65,13 +143,64 @@ dataset:
         release_date: "2025-02-25"
         tables:
           - dtypes:
-              Consumption: str
-              Fuel: str
-              Payment method: str
-              Price cap period: str
-              Tariff component: str
+              consumption: str
+              fuel: str
+              payment_method: str
+              price_cap_period: str
+              price_cap_period_end: datetime64[ns]
+              price_cap_period_start: datetime64[ns]
+              tariff_component: str
               value: float
             sheet_name: 1c Consumption adjusted levels
+  english_housing_survey:
+    collection_url: https://www.gov.uk/government/collections/english-housing-survey
+    versions:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/english_housing_survey/2023-24_EHS_Headline_Report_Chapter_1_Housing_Quality_Annex_Tables.ods
+          - s3://asf-mission-data-tool/bronze/english_housing_survey/2023-24_EHS_Headline_Report_Chapter_2_Energy_Efficiency_Annex_Tables.ods
+        file_silver:
+          - s3://asf-mission-data-tool/silver/english_housing_survey/January_2025/2023-24_EHS_Headline_Report_Chapter_2_Energy_Efficiency_Annex_Tables_AT2_5.parquet
+          - s3://asf-mission-data-tool/silver/english_housing_survey/January_2025/2023-24_EHS_Headline_Report_Chapter_2_Energy_Efficiency_Annex_Tables_AT2_6.parquet
+          - s3://asf-mission-data-tool/silver/english_housing_survey/January_2025/2023-24_EHS_Headline_Report_Chapter_2_Energy_Efficiency_Annex_Tables_AT2_7.parquet
+          - s3://asf-mission-data-tool/silver/english_housing_survey/January_2025/2023-24_EHS_Headline_Report_Chapter_2_Energy_Efficiency_Annex_Tables_AT2_8.parquet
+        file_url:
+          - https://assets.publishing.service.gov.uk/media/6799e37e9a6dc0352ab34216/2023-24_EHS_Headline_Report_Chapter_1_Housing_Quality_Annex_Tables.ods
+          - https://assets.publishing.service.gov.uk/media/6799e38c1c041dcc469dae78/2023-24_EHS_Headline_Report_Chapter_2_Energy_Efficiency_Annex_Tables.ods
+        page_url: https://www.gov.uk/government/statistics/annex-tables-for-english-housing-survey-2023-to-2024-headline-findings-on-housing-quality-and-energy-efficiency
+        release_date: "2025-01-30"
+        tables:
+          - dtypes:
+              main_heating_system: str
+              unit: str
+              value: float64
+              year: Int64
+            file_url: https://assets.publishing.service.gov.uk/media/6799e38c1c041dcc469dae78/2023-24_EHS_Headline_Report_Chapter_2_Energy_Efficiency_Annex_Tables.ods
+            sheet_name: AT2_5
+            skiprows: 4
+          - dtypes:
+              tenure: str
+              unit: str
+              value: float64
+              variable: str
+            file_url: https://assets.publishing.service.gov.uk/media/6799e38c1c041dcc469dae78/2023-24_EHS_Headline_Report_Chapter_2_Energy_Efficiency_Annex_Tables.ods
+            sheet_name: AT2_6
+            skiprows: 4
+          - dtypes:
+              boiler_type: str
+              unit: str
+              value: float64
+              year: Int64
+            file_url: https://assets.publishing.service.gov.uk/media/6799e38c1c041dcc469dae78/2023-24_EHS_Headline_Report_Chapter_2_Energy_Efficiency_Annex_Tables.ods
+            sheet_name: AT2_7
+            skiprows: 4
+          - dtypes:
+              tenure: str
+              unit: str
+              value: float64
+              variable: str
+            file_url: https://assets.publishing.service.gov.uk/media/6799e38c1c041dcc469dae78/2023-24_EHS_Headline_Report_Chapter_2_Energy_Efficiency_Annex_Tables.ods
+            sheet_name: AT2_8
+            skiprows: 4
   fuel_poverty_statistics:
     collection_url: https://www.gov.uk/government/collections/fuel-poverty-statistics
     versions:
@@ -81,6 +210,222 @@ dataset:
           - https://assets.publishing.service.gov.uk/media/65cca543130549000c8679b9/2023-fuel-poverty-detailed-tables-xls.xlsx
         page_url: https://www.gov.uk/government/statistics/fuel-poverty-detailed-tables-2024-2023-data
         release_date: "2024-02-15"
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/fuel_poverty_statistics/2024_Detailed_Tables_Final.xlsx
+        file_silver:
+          - s3://asf-mission-data-tool/silver/fuel_poverty_statistics/March_2025/2024_Detailed_Tables_Final_Table_1_by_all_households_and_vulnerable_households.parquet
+          - s3://asf-mission-data-tool/silver/fuel_poverty_statistics/March_2025/2024_Detailed_Tables_Final_Table_2_by_quadrant_of_lileee_matrix.parquet
+          - s3://asf-mission-data-tool/silver/fuel_poverty_statistics/March_2025/2024_Detailed_Tables_Final_Table_3_by_fuel_poverty_energy_efficiency_rating_fpeer.parquet
+          - s3://asf-mission-data-tool/silver/fuel_poverty_statistics/March_2025/2024_Detailed_Tables_Final_Table_5_by_rurality_and_fpeer.parquet
+          - s3://asf-mission-data-tool/silver/fuel_poverty_statistics/March_2025/2024_Detailed_Tables_Final_Table_6_by_region.parquet
+          - s3://asf-mission-data-tool/silver/fuel_poverty_statistics/March_2025/2024_Detailed_Tables_Final_Table_7_by_dwelling_type.parquet
+          - s3://asf-mission-data-tool/silver/fuel_poverty_statistics/March_2025/2024_Detailed_Tables_Final_Table_8_by_age_of_dwelling.parquet
+          - s3://asf-mission-data-tool/silver/fuel_poverty_statistics/March_2025/2024_Detailed_Tables_Final_Table_9_by_floor_area.parquet
+          - s3://asf-mission-data-tool/silver/fuel_poverty_statistics/March_2025/2024_Detailed_Tables_Final_Table_10_by_gas_grid_connection_and_fpeer.parquet
+          - s3://asf-mission-data-tool/silver/fuel_poverty_statistics/March_2025/2024_Detailed_Tables_Final_Table_11_by_central_heating_and_fpeer.parquet
+          - s3://asf-mission-data-tool/silver/fuel_poverty_statistics/March_2025/2024_Detailed_Tables_Final_Table_12_by_main_fuel_type_and_fpeer.parquet
+          - s3://asf-mission-data-tool/silver/fuel_poverty_statistics/March_2025/2024_Detailed_Tables_Final_Table_13_by_central_heating_and_fuel.parquet
+          - s3://asf-mission-data-tool/silver/fuel_poverty_statistics/March_2025/2024_Detailed_Tables_Final_Table_14_by_boiler_type.parquet
+          - s3://asf-mission-data-tool/silver/fuel_poverty_statistics/March_2025/2024_Detailed_Tables_Final_Table_15_by_wall_insulation_and_fpeer.parquet
+          - s3://asf-mission-data-tool/silver/fuel_poverty_statistics/March_2025/2024_Detailed_Tables_Final_Table_16_by_wall_type_and_gas_grid_connection.parquet
+          - s3://asf-mission-data-tool/silver/fuel_poverty_statistics/March_2025/2024_Detailed_Tables_Final_Table_17_by_loft_insulation.parquet
+          - s3://asf-mission-data-tool/silver/fuel_poverty_statistics/March_2025/2024_Detailed_Tables_Final_Table_18_by_renewable_heat_technology_and_fpeer.parquet
+          - s3://asf-mission-data-tool/silver/fuel_poverty_statistics/March_2025/2024_Detailed_Tables_Final_Table_19_by_tenure_and_fpeer.parquet
+          - s3://asf-mission-data-tool/silver/fuel_poverty_statistics/March_2025/2024_Detailed_Tables_Final_Table_20_by_housing_sector.parquet
+          - s3://asf-mission-data-tool/silver/fuel_poverty_statistics/March_2025/2024_Detailed_Tables_Final_Table_24_by_household_size.parquet
+          - s3://asf-mission-data-tool/silver/fuel_poverty_statistics/March_2025/2024_Detailed_Tables_Final_Table_29_by_tenure_and_vulnerability.parquet
+          - s3://asf-mission-data-tool/silver/fuel_poverty_statistics/March_2025/2024_Detailed_Tables_Final_Table_31_by_income_decile_and_fpeer.parquet
+          - s3://asf-mission-data-tool/silver/fuel_poverty_statistics/March_2025/2024_Detailed_Tables_Final_Table_32_by_gas_payment_method.parquet
+          - s3://asf-mission-data-tool/silver/fuel_poverty_statistics/March_2025/2024_Detailed_Tables_Final_Table_33_by_electricity_payment_method.parquet
+          - s3://asf-mission-data-tool/silver/fuel_poverty_statistics/March_2025/2024_Detailed_Tables_Final_Table_34_by_benefit_receipt.parquet
+          - s3://asf-mission-data-tool/silver/fuel_poverty_statistics/March_2025/2024_Detailed_Tables_Final_Table_35_by_eco4_hthg_eligibility.parquet
+        file_url:
+          - https://assets.publishing.service.gov.uk/media/67e3cff6dcd2d93561195bdc/2024_Detailed_Tables_Final.xlsx
+        page_url: https://www.gov.uk/government/statistics/fuel-poverty-detailed-tables-2025-2024-data
+        release_date: "2025-03-27"
+        tables:
+          - dtypes:
+              category: str
+              group: str
+              value: float64
+              variable: str
+            sheet_name: Table 1
+            skiprows: 2
+          - dtypes:
+              category: str
+              group: str
+              value: float64
+              variable: str
+            sheet_name: Table 2
+            skiprows: 2
+          - dtypes:
+              category: str
+              group: str
+              value: float64
+              variable: str
+            sheet_name: Table 3
+            skiprows: 2
+          - dtypes:
+              FPEER band: str
+              Rurality: str
+              value: float64
+              variable: str
+            sheet_name: Table 5
+            skiprows: 2
+          - dtypes:
+              category: str
+              group: str
+              value: float64
+              variable: str
+            sheet_name: Table 6
+            skiprows: 2
+          - dtypes:
+              category: str
+              group: str
+              value: float64
+              variable: str
+            sheet_name: Table 7
+            skiprows: 2
+          - dtypes:
+              category: str
+              group: str
+              value: float64
+              variable: str
+            sheet_name: Table 8
+            skiprows: 2
+          - dtypes:
+              category: str
+              group: str
+              value: float64
+              variable: str
+            sheet_name: Table 9
+            skiprows: 2
+          - dtypes:
+              FPEER band: str
+              Gas grid connection: str
+              value: float64
+              variable: str
+            sheet_name: Table 10
+            skiprows: 2
+          - dtypes:
+              Central heating: str
+              FPEER band: str
+              value: float64
+              variable: str
+            sheet_name: Table 11
+            skiprows: 2
+          - dtypes:
+              FPEER band: str
+              Main fuel type: str
+              value: float64
+              variable: str
+            sheet_name: Table 12
+            skiprows: 2
+          - dtypes:
+              Central heating: str
+              Main fuel type: str
+              value: float64
+              variable: str
+            sheet_name: Table 13
+            skiprows: 2
+          - dtypes:
+              category: str
+              group: str
+              value: float64
+              variable: str
+            sheet_name: Table 14
+            skiprows: 2
+          - dtypes:
+              FPEER band: str
+              Wall insulation [Note B]: str
+              value: float64
+              variable: str
+            sheet_name: Table 15
+            skiprows: 2
+          - dtypes:
+              Gas grid connection: str
+              Wall type: str
+              value: float64
+              variable: str
+            sheet_name: Table 16
+            skiprows: 2
+          - dtypes:
+              category: str
+              group: str
+              value: float64
+              variable: str
+            sheet_name: Table 17
+            skiprows: 2
+          - dtypes:
+              FPEER band: str
+              Renewable heat technology: str
+              value: float64
+              variable: str
+            sheet_name: Table 18
+            skiprows: 2
+          - dtypes:
+              FPEER band: str
+              Tenure [Note A]: str
+              value: float64
+              variable: str
+            sheet_name: Table 19
+            skiprows: 2
+          - dtypes:
+              category: str
+              group: str
+              value: float64
+              variable: str
+            sheet_name: Table 20
+            skiprows: 2
+          - dtypes:
+              category: str
+              group: str
+              value: float64
+              variable: str
+            sheet_name: Table 24
+            skiprows: 2
+          - dtypes:
+              Tenure: str
+              Vulnerability: str
+              value: float64
+              variable: str
+            sheet_name: Table 29
+            skiprows: 2
+          - dtypes:
+              After Housing Costs (AHC) equivalised income decile group: str
+              FPEER band: str
+              value: float64
+              variable: str
+            sheet_name: Table 31
+            skiprows: 2
+          - dtypes:
+              category: str
+              group: str
+              value: float64
+              variable: str
+            sheet_name: Table 32
+            skiprows: 2
+          - dtypes:
+              category: str
+              group: str
+              value: float64
+              variable: str
+            sheet_name: Table 33
+            skiprows: 2
+          - dtypes:
+              category: str
+              group: str
+              value: float64
+              variable: str
+            sheet_name: Table 34
+            skiprows: 2
+          - dtypes:
+              category: str
+              group: str
+              value: float64
+              variable: str
+            sheet_name: Table 35
+            skiprows: 2
   future_energy_scenarios:
     collection_url: https://www.neso.energy/publications/future-energy-scenarios-fes
     versions:
@@ -95,6 +440,44 @@ dataset:
     collection_url: https://www.gov.uk/government/collections/heat-pump-deployment-statistics
     versions:
       - file_bronze:
+          - s3://asf-mission-data-tool/bronze/heat_pump_deployment_quarterly_statistics/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2024_Q4.xlsx
+        file_silver:
+          - s3://asf-mission-data-tool/silver/heat_pump_deployment_quarterly_statistics/March_2025/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2024_Q4_Table_1_1.parquet
+          - s3://asf-mission-data-tool/silver/heat_pump_deployment_quarterly_statistics/March_2025/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2024_Q4_Table_1_2.parquet
+          - s3://asf-mission-data-tool/silver/heat_pump_deployment_quarterly_statistics/March_2025/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2024_Q4_Table_1_3.parquet
+        file_url:
+          - https://assets.publishing.service.gov.uk/media/67c7427a68a61757838d22ce/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2024_Q4.xlsx
+        page_url: https://www.gov.uk/government/statistics/heat-pump-deployment-statistics-december-2024
+        release_date: "2025-03-06"
+        tables:
+          - dtypes:
+              end_of_quarter: datetime64[ns]
+              government_scheme: str
+              installation_quarter: str
+              installations: int64
+              start_of_quarter: datetime64[ns]
+              year: Int64
+            sheet_name: Table 1.1
+            skiprows: 5
+          - dtypes:
+              end_of_quarter: datetime64[ns]
+              installation_quarter: str
+              installations: int64
+              start_of_quarter: datetime64[ns]
+              technology_type: str
+              year: Int64
+            sheet_name: Table 1.2
+            skiprows: 5
+          - dtypes:
+              end_of_quarter: datetime64[ns]
+              installation_quarter: str
+              installations: int64
+              region: str
+              start_of_quarter: datetime64[ns]
+              year: Int64
+            sheet_name: Table 1.3
+            skiprows: 9
+      - file_bronze:
           - s3://asf-mission-data-tool/bronze/heat_pump_deployment_quarterly_statistics/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2024_Q3.xlsx
         file_silver:
           - s3://asf-mission-data-tool/silver/heat_pump_deployment_quarterly_statistics/December_2024/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2024_Q3_Table_1_1.parquet
@@ -106,43 +489,30 @@ dataset:
         release_date: "2024-12-05"
         tables:
           - dtypes:
-              All schemes: int
-              Boiler Upgrade Scheme[Note 5]: int
-              Domestic Renewable Heat Incentive[note 11]: int
-              Energy Company Obligation[Note 10]: int
-              Green Homes Grant Voucher Scheme[Note 8]: int
-              Home Upgrade Grant[Note 6]: int
-              Installation quarter [note 4]: str
-              Local Authority Delivery[note 7]: int
-              Non-Domestic Renewable Heat Incentive[Note 12]: int
-              Social Housing Decarbonisation Fund[Note 9]: int
+              end_of_quarter: datetime64[ns]
+              government_scheme: str
+              installation_quarter: str
+              installations: int64
+              start_of_quarter: datetime64[ns]
+              year: Int64
             sheet_name: Table 1.1
             skiprows: 5
           - dtypes:
-              Air source heat pumps [note 13]: int
-              All technologies: int
-              Ground/water source heat pumps [note 13]: int
-              Installation quarter [note 4]: str
-              Unknown technology [note 14]: int
+              end_of_quarter: datetime64[ns]
+              installation_quarter: str
+              installations: int64
+              start_of_quarter: datetime64[ns]
+              technology_type: str
+              year: Int64
             sheet_name: Table 1.2
             skiprows: 5
           - dtypes:
-              East: int
-              East Midlands: int
-              England: int
-              England and Wales: int
-              Installation quarter [note 4]: str
-              London: int
-              North East: int
-              North West: int
-              Northern Ireland: int
-              Scotland: int
-              South East: int
-              South West: int
-              United Kingdom: int
-              Wales: int
-              West Midlands: int
-              Yorkshire and The Humber: int
+              end_of_quarter: datetime64[ns]
+              installation_quarter: str
+              installations: int64
+              region: str
+              start_of_quarter: datetime64[ns]
+              year: Int64
             sheet_name: Table 1.3
             skiprows: 9
       - file_url: https://assets.publishing.service.gov.uk/media/66f53fee080bdf716392e93f/Heat_pump_deployment_quarterly_statistics_United_Kingdom_June_2024.xlsx
@@ -163,19 +533,41 @@ dataset:
       - file_bronze:
           - s3://asf-mission-data-tool/bronze/public_attitudes_tracking_survey/DESNZ_PAT_Summer_2024_Time_Series.xlsx
           - s3://asf-mission-data-tool/bronze/public_attitudes_tracking_survey/DESNZ_PAT_Summer_2024_Crosstabulations.xlsx
+        file_silver: s3://asf-mission-data-tool/silver/public_attitudes_tracking_survey/October_2024/DESNZ_PAT_Summer_2024_Time_Series_all_questions.parquet
         file_url:
           - https://assets.publishing.service.gov.uk/media/671a182f593bb124be9c13dc/DESNZ_PAT_Summer_2024_Time_Series.xlsx
           - https://assets.publishing.service.gov.uk/media/671a181a593bb124be9c13db/DESNZ_PAT_Summer_2024_Crosstabulations.xlsx
         page_url: https://www.gov.uk/government/statistics/desnz-public-attitudes-tracker-summer-2024
         release_date: "2024-10-29"
+        tables:
+          - dtypes:
+              question: str
+              season_end_date: datetime64[ns]
+              season_start_date: datetime64[ns]
+              value: float64
+              variable: str
+              variable_type: str
+              wave_season: str
+              wave_year: int64
       - file_bronze:
           - s3://asf-mission-data-tool/bronze/public_attitudes_tracking_survey/DESNZ_PAT_Spring_2024_Time_series.xlsx
           - s3://asf-mission-data-tool/bronze/public_attitudes_tracking_survey/DESNZ_PAT__Spring_2024__Crosstabulations.xlsx
+        file_silver: s3://asf-mission-data-tool/silver/public_attitudes_tracking_survey/July_2024/DESNZ_PAT_Spring_2024_Time_series_all_questions.parquet
         file_url:
           - https://assets.publishing.service.gov.uk/media/6682749697ea0c79abfe4dc0/DESNZ_PAT_Spring_2024_Time_series.xlsx
           - https://assets.publishing.service.gov.uk/media/668274ab7d26b2be17a4b4c1/DESNZ_PAT__Spring_2024__Crosstabulations.xlsx
         page_url: https://www.gov.uk/government/statistics/desnz-public-attitudes-tracker-spring-2024
         release_date: "2024-07-03"
+        tables:
+          - dtypes:
+              question: str
+              season_end_date: datetime64[ns]
+              season_start_date: datetime64[ns]
+              value: float64
+              variable: str
+              variable_type: str
+              wave_season: str
+              wave_year: int64
       - file_bronze:
           - s3://asf-mission-data-tool/bronze/public_attitudes_tracking_survey/DESNZ_Public_Attitudes_Tracker_Winter_2023_Time_Series.xlsx
           - s3://asf-mission-data-tool/bronze/public_attitudes_tracking_survey/DESNZ_Public_Attitudes_Tracker_Winter_2023_Crosstabulations__Revised_July_2024_.xlsx
@@ -184,6 +576,35 @@ dataset:
           - https://assets.publishing.service.gov.uk/media/66829a4e7d26b2be17a4b4f2/DESNZ_Public_Attitudes_Tracker_Winter_2023_Crosstabulations__Revised_July_2024_.xlsx
         page_url: https://www.gov.uk/government/statistics/desnz-public-attitudes-tracker-winter-2023
         release_date: "2024-03-07"
+        tables:
+          - dtypes:
+              question: str
+              season_end_date: datetime64[ns]
+              season_start_date: datetime64[ns]
+              value: float64
+              variable: str
+              variable_type: str
+              wave_season: str
+              wave_year: int64
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/public_attitudes_tracking_survey/DESNZ_Public_Attitudes_Tracker__Winter_2024__Time_Series.xlsx
+          - s3://asf-mission-data-tool/bronze/public_attitudes_tracking_survey/DESNZ_Public_Attitudes_Tracker__Winter_2024__Crosstabulations.xlsx
+        file_silver: s3://asf-mission-data-tool/silver/public_attitudes_tracking_survey/March_2025/DESNZ_Public_Attitudes_Tracker__Winter_2024__Time_Series_all_questions.parquet
+        file_url:
+          - https://assets.publishing.service.gov.uk/media/67d04bad472ec44ed2307842/DESNZ_Public_Attitudes_Tracker__Winter_2024__Time_Series.xlsx
+          - https://assets.publishing.service.gov.uk/media/67d04bc8ad017430364eef04/DESNZ_Public_Attitudes_Tracker__Winter_2024__Crosstabulations.xlsx
+        page_url: https://www.gov.uk/government/statistics/desnz-public-attitudes-tracker-winter-2024
+        release_date: "2025-03-13"
+        tables:
+          - dtypes:
+              question: str
+              season_end_date: datetime64[ns]
+              season_start_date: datetime64[ns]
+              value: float64
+              variable: str
+              variable_type: str
+              wave_season: str
+              wave_year: int64
   scottish_house_condition_survey:
     collection_url: https://www.gov.scot/collections/scottish-house-condition-survey/
     versions:
@@ -208,72 +629,141 @@ dataset:
     versions:
       - file_bronze:
           - s3://asf-mission-data-tool/bronze/seventh_carbon_budget/The-Seventh-Carbon-Budget-full-dataset.xlsx
+          - s3://asf-mission-data-tool/bronze/seventh_carbon_budget/The-Seventh-Carbon-Budget-Charts-and-data-in-the-report.xlsx
+        file_silver:
+          - s3://asf-mission-data-tool/silver/seventh_carbon_budget/February_2025/The-Seventh-Carbon-Budget-full-dataset_Economy_wide_data.parquet
+          - s3://asf-mission-data-tool/silver/seventh_carbon_budget/February_2025/The-Seventh-Carbon-Budget-full-dataset_Sector_level_data.parquet
+          - s3://asf-mission-data-tool/silver/seventh_carbon_budget/February_2025/The-Seventh-Carbon-Budget-full-dataset_Subsector_level_data.parquet
+          - s3://asf-mission-data-tool/silver/seventh_carbon_budget/February_2025/The-Seventh-Carbon-Budget-full-dataset_Measure_level_data.parquet
+          - s3://asf-mission-data-tool/silver/seventh_carbon_budget/February_2025/The-Seventh-Carbon-Budget-Charts-and-data-in-the-report_3_5.parquet
+          - s3://asf-mission-data-tool/silver/seventh_carbon_budget/February_2025/The-Seventh-Carbon-Budget-Charts-and-data-in-the-report_7_2_1.parquet
+          - s3://asf-mission-data-tool/silver/seventh_carbon_budget/February_2025/The-Seventh-Carbon-Budget-Charts-and-data-in-the-report_7_2_4.parquet
+          - s3://asf-mission-data-tool/silver/seventh_carbon_budget/February_2025/The-Seventh-Carbon-Budget-Charts-and-data-in-the-report_7_2_2.parquet
         file_url:
           - https://www.theccc.org.uk/wp-content/uploads/2025/02/The-Seventh-Carbon-Budget-full-dataset.xlsx
+          - https://www.theccc.org.uk/wp-content/uploads/2025/02/The-Seventh-Carbon-Budget-Charts-and-data-in-the-report.xlsx
         page_url: https://www.theccc.org.uk/publication/the-seventh-carbon-budget/#publication-downloads
         release_date: "2025-02-26"
-  sixth_carbon_budget:
-    collection_url: https://www.theccc.org.uk/publication/sixth-carbon-budget/
-    versions:
-      - file_bronze:
-          - s3://asf-mission-data-tool/bronze/sixth_carbon_budget/The-Sixth-Carbon-Budget-Dataset_v2.xlsx
-        file_url:
-          - https://www.theccc.org.uk/wp-content/uploads/2020/12/The-Sixth-Carbon-Budget-Dataset_v2.xlsx
-        page_url: https://www.theccc.org.uk/publication/sixth-carbon-budget/#supporting-information-charts-and-data
-        release_date: "2020-12-09"
         tables:
-          - sheet_name: Buildings additional data
-            skipcols: 1
-            skiprows: 38
           - dtypes:
-              Metric index: str
-              Scenario: str
-              Region: str
-              Sector: str
-              Amalgamation: str
-              Metric: str
-              Units: str
-              2020: float
-              2021: float
-              2022: float
-              2023: float
-              2024: float
-              2025: float
-              2026: float
-              2027: float
-              2028: float
-              2029: float
-              2030: float
-              2031: float
-              2032: float
-              2033: float
-              2034: float
-              2035: float
-              2036: float
-              2037: float
-              2038: float
-              2039: float
-              2040: float
-              2041: float
-              2042: float
-              2043: float
-              2044: float
-              2045: float
-              2046: float
-              2047: float
-              2048: float
-              2049: float
-              2050: float
-            sheet_name: Raw data
-            skipcols: 1
-            skiprows: 1
+              country: str
+              scenario: str
+              value: float
+              variable: str
+              variable_unit: str
+              year: int
+            file_url: https://www.theccc.org.uk/wp-content/uploads/2025/02/The-Seventh-Carbon-Budget-full-dataset.xlsx
+            sheet_name: Economy-wide data
+          - dtypes:
+              country: str
+              scenario: str
+              sector: str
+              value: float
+              variable: str
+              variable_unit: str
+              year: int
+            file_url: https://www.theccc.org.uk/wp-content/uploads/2025/02/The-Seventh-Carbon-Budget-full-dataset.xlsx
+            sheet_name: Sector-level data
+          - dtypes:
+              country: str
+              scenario: str
+              sector: str
+              subsector: str
+              value: float
+              variable: str
+              variable_unit: str
+              year: int
+            file_url: https://www.theccc.org.uk/wp-content/uploads/2025/02/The-Seventh-Carbon-Budget-full-dataset.xlsx
+            sheet_name: Subsector-level data
+          - dtypes:
+              category3: str
+              category4: str
+              category5: str
+              category6: str
+              category7: str
+              country: str
+              measure_name: str
+              scenario: str
+              sector: str
+              subsector: str
+              value: float
+              variable: str
+              variable_unit: str
+              year: int
+            file_url: https://www.theccc.org.uk/wp-content/uploads/2025/02/The-Seventh-Carbon-Budget-full-dataset.xlsx
+            sheet_name: Measure-level data
+          - dtypes:
+              Category: str
+              Pathway: str
+              Series: str
+              Value: float64
+              Year: int64
+            file_url: https://www.theccc.org.uk/wp-content/uploads/2025/02/The-Seventh-Carbon-Budget-Charts-and-data-in-the-report.xlsx
+            sheet_name: "3.5"
+            skipcols: 10
+            skiprows: 10
+          - dtypes:
+              Emissions (MtCO2e): float64
+              Series: str
+              Subsector: str
+              Year: int64
+            file_url: https://www.theccc.org.uk/wp-content/uploads/2025/02/The-Seventh-Carbon-Budget-Charts-and-data-in-the-report.xlsx
+            sheet_name: 7.2.1
+            skipcols: 10
+            skiprows: 10
+          - dtypes:
+              Name: str
+              Series: str
+              Unit: str
+              Value: float64
+              Year: int64
+            file_url: https://www.theccc.org.uk/wp-content/uploads/2025/02/The-Seventh-Carbon-Budget-Charts-and-data-in-the-report.xlsx
+            sheet_name: 7.2.4
+            skiprows: 12
+          - dtypes:
+              Category: str
+              Pathway: str
+              Value: float64
+              Year: int64
+            file_url: https://www.theccc.org.uk/wp-content/uploads/2025/02/The-Seventh-Carbon-Budget-Charts-and-data-in-the-report.xlsx
+            sheet_name: 7.2.2
+            skipcols: 10
+            skiprows: 10
   uk_territorial_greenhouse_gas_emissions_statistics:
     collection_url: https://www.gov.uk/government/collections/uk-territorial-greenhouse-gas-emissions-statistics
     versions:
-      - file_url:
-          - https://assets.publishing.service.gov.uk/media/660305b1c34a860011be75f2/2023-provisional-emissions-data-tables.xlsx
-        page_url: https://www.gov.uk/government/statistics/provisional-uk-greenhouse-gas-emissions-national-statistics-2023
-        release_date: "2024-03-28"
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/uk_territorial_greenhouse_gas_emissions_statistics/final-greenhouse-gas-emissions-tables-2023.xlsx
+          - s3://asf-mission-data-tool/bronze/uk_territorial_greenhouse_gas_emissions_statistics/final-greenhouse-gas-emissions-end-user-tables-2023.xlsx
+        file_silver:
+          - s3://asf-mission-data-tool/silver/uk_territorial_greenhouse_gas_emissions_statistics/February_2025/final-greenhouse-gas-emissions-tables-2023_1_2.parquet
+          - s3://asf-mission-data-tool/silver/uk_territorial_greenhouse_gas_emissions_statistics/February_2025/final-greenhouse-gas-emissions-end-user-tables-2023_7_1.parquet
+        file_url:
+          - https://assets.publishing.service.gov.uk/media/67a379ffb74b3d9dfe36ca9e/final-greenhouse-gas-emissions-tables-2023.xlsx
+          - https://assets.publishing.service.gov.uk/media/67e3e5688ca840c1439a72ea/final-greenhouse-gas-emissions-end-user-tables-2023.xlsx
+        page_url: https://www.gov.uk/government/statistics/final-uk-greenhouse-gas-emissions-statistics-1990-to-2023
+        release_date: "2025-02-06"
+        tables:
+          - dtypes:
+              territorial_greenhouse_gas_emissions: float
+              tes_category: str
+              tes_sector: str
+              tes_subsector: str
+              unit: str
+              year: int64
+            file_url: https://assets.publishing.service.gov.uk/media/67a379ffb74b3d9dfe36ca9e/final-greenhouse-gas-emissions-tables-2023.xlsx
+            sheet_name: "1.2"
+            skiprows: 5
+          - dtypes:
+              territorial_greenhouse_gas_emissions: float
+              tes_category: str
+              tes_sector: str
+              tes_subsector: str
+              unit: str
+              year: int64
+            file_url: https://assets.publishing.service.gov.uk/media/67e3e5688ca840c1439a72ea/final-greenhouse-gas-emissions-end-user-tables-2023.xlsx
+            sheet_name: "7.1"
+            skiprows: 6
       - file_bronze:
           - s3://asf-mission-data-tool/bronze/uk_territorial_greenhouse_gas_emissions_statistics/final-greenhouse-gas-emissions-tables-2022.xlsx
           - s3://asf-mission-data-tool/bronze/uk_territorial_greenhouse_gas_emissions_statistics/final-greenhouse-gas-emissions-end-user-tables-2022.xlsx
@@ -289,82 +779,22 @@ dataset:
         release_date: "2024-02-06"
         tables:
           - dtypes:
-              "1990": float
-              "1991": float
-              "1992": float
-              "1993": float
-              "1994": float
-              "1995": float
-              "1996": float
-              "1997": float
-              "1998": float
-              "1999": float
-              "2000": float
-              "2001": float
-              "2002": float
-              "2003": float
-              "2004": float
-              "2005": float
-              "2006": float
-              "2007": float
-              "2008": float
-              "2009": float
-              "2010": float
-              "2011": float
-              "2012": float
-              "2013": float
-              "2014": float
-              "2015": float
-              "2016": float
-              "2017": float
-              "2018": float
-              "2019": float
-              "2020": float
-              "2021": float
-              "2022": float
-              TES Category: str
-              TES Sector: str
-              TES Subsector: str
+              territorial_greenhouse_gas_emissions: float
+              tes_category: str
+              tes_sector: str
+              tes_subsector: str
+              unit: str
+              year: int64
             file_url: https://assets.publishing.service.gov.uk/media/65ff114a65ca2ffef17da7a6/final-greenhouse-gas-emissions-tables-2022.xlsx
             sheet_name: "1.2"
             skiprows: 6
           - dtypes:
-              "1990": float
-              "1991": float
-              "1992": float
-              "1993": float
-              "1994": float
-              "1995": float
-              "1996": float
-              "1997": float
-              "1998": float
-              "1999": float
-              "2000": float
-              "2001": float
-              "2002": float
-              "2003": float
-              "2004": float
-              "2005": float
-              "2006": float
-              "2007": float
-              "2008": float
-              "2009": float
-              "2010": float
-              "2011": float
-              "2012": float
-              "2013": float
-              "2014": float
-              "2015": float
-              "2016": float
-              "2017": float
-              "2018": float
-              "2019": float
-              "2020": float
-              "2021": float
-              "2022": float
-              TES Category: str
-              TES Sector: str
-              TES Subsector: str
+              territorial_greenhouse_gas_emissions: float
+              tes_category: str
+              tes_sector: str
+              tes_subsector: str
+              unit: str
+              year: int64
             file_url: https://assets.publishing.service.gov.uk/media/66044b8cf9ab410011eea42d/final-greenhouse-gas-emissions-end-user-tables-2022.xlsx
             sheet_name: "7.1"
             skiprows: 6

--- a/asf_mission_data_tool/config/base.yaml
+++ b/asf_mission_data_tool/config/base.yaml
@@ -556,6 +556,38 @@ dataset:
       - file_url: https://assets.publishing.service.gov.uk/media/66f53fee080bdf716392e93f/Heat_pump_deployment_quarterly_statistics_United_Kingdom_June_2024.xlsx
         page_url: https://www.gov.uk/government/statistics/heat-pump-deployment-statistics-june-2024
         release_date: "2024-09-26"
+      - file_url:
+          - https://assets.publishing.service.gov.uk/media/68b5c751536d629f9c82a983/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2025_Q2.xlsx
+        page_url: https://www.gov.uk/government/statistics/heat-pump-deployment-statistics-june-2025
+        release_date: "2025-09-04"
+        tables:
+          - dtypes:
+              end_of_quarter: datetime64[ns]
+              government_scheme: str
+              installation_quarter: str
+              installations: int64
+              start_of_quarter: datetime64[ns]
+              year: Int64
+            sheet_name: Table 1.1
+            skiprows: 5
+          - dtypes:
+              end_of_quarter: datetime64[ns]
+              installation_quarter: str
+              installations: int64
+              start_of_quarter: datetime64[ns]
+              technology_type: str
+              year: Int64
+            sheet_name: Table 1.2
+            skiprows: 5
+          - dtypes:
+              end_of_quarter: datetime64[ns]
+              installation_quarter: str
+              installations: int64
+              region: str
+              start_of_quarter: datetime64[ns]
+              year: Int64
+            sheet_name: Table 1.3
+            skiprows: 9
   northern_ireland_statistics_and_research_agency_census:
     collection_url: https://www.nisra.gov.uk/statistics/census
     versions:

--- a/asf_mission_data_tool/config/base.yaml
+++ b/asf_mission_data_tool/config/base.yaml
@@ -130,6 +130,15 @@ dataset:
           - https://www.gov.scot/binaries/content/documents/govscot/publications/statistics/2025/01/scottish-house-condition-survey-2023-key-findings/documents/shcs-2023--chapter-06-bedroom-standard--tables-and-figures/shcs-2023--chapter-06-bedroom-standard--tables-and-figures/govscot%3Adocument/SHCS%2B2023-%2BChapter%2B06%2BBedroom%2BStandard-%2Btables%2Band%2Bfigures.ods
         page_url: https://www.gov.scot/publications/scottish-house-condition-survey-2023-key-findings/documents/
         release_date: "2025-01-28"
+  seventh_carbon_budget:
+    collection_url: https://www.theccc.org.uk/publication/the-seventh-carbon-budget/
+    versions:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/seventh_carbon_budget/The-Seventh-Carbon-Budget-full-dataset.xlsx
+        file_url:
+          - https://www.theccc.org.uk/wp-content/uploads/2025/02/The-Seventh-Carbon-Budget-full-dataset.xlsx
+        page_url: https://www.theccc.org.uk/publication/the-seventh-carbon-budget/#publication-downloads
+        release_date: "2025-02-26"
   sixth_carbon_budget:
     collection_url: https://www.theccc.org.uk/publication/sixth-carbon-budget/
     versions:

--- a/asf_mission_data_tool/config/base.yaml
+++ b/asf_mission_data_tool/config/base.yaml
@@ -569,6 +569,25 @@ dataset:
     collection_url: https://www.gov.uk/government/collections/public-attitudes-tracking-survey
     versions:
       - file_bronze:
+          - s3://asf-mission-data-tool/bronze/public_attitudes_tracking_survey/DESNZ_Public_Attitudes_Tracker_-_Time_series__Spring_2025__UK.xlsx
+          - s3://asf-mission-data-tool/bronze/public_attitudes_tracking_survey/DESNZ_Public_Attitudes_Tracker-_Crosstabulations__Spring_2025__UK.xlsx
+        file_silver: s3://asf-mission-data-tool/silver/public_attitudes_tracking_survey/July_2025/DESNZ_Public_Attitudes_Tracker_-_Time_series__Spring_2025__UK_all_questions.parquet
+        file_url:
+          - https://assets.publishing.service.gov.uk/media/686298ea08bf2f5376121a26/DESNZ_Public_Attitudes_Tracker_-_Time_series__Spring_2025__UK.xlsx
+          - https://assets.publishing.service.gov.uk/media/68629a37b466cce1bb121a34/DESNZ_Public_Attitudes_Tracker-_Crosstabulations__Spring_2025__UK.xlsx
+        page_url: https://www.gov.uk/government/statistics/desnz-public-attitudes-tracker-spring-2025
+        release_date: "2025-07-03"
+        tables:
+          - dtypes:
+              question: str
+              season_end_date: datetime64[ns]
+              season_start_date: datetime64[ns]
+              value: float64
+              variable: str
+              variable_type: str
+              wave_season: str
+              wave_year: int64
+      - file_bronze:
           - s3://asf-mission-data-tool/bronze/public_attitudes_tracking_survey/DESNZ_PAT_Summer_2024_Time_Series.xlsx
           - s3://asf-mission-data-tool/bronze/public_attitudes_tracking_survey/DESNZ_PAT_Summer_2024_Crosstabulations.xlsx
         file_silver: s3://asf-mission-data-tool/silver/public_attitudes_tracking_survey/October_2024/DESNZ_PAT_Summer_2024_Time_Series_all_questions.parquet

--- a/asf_mission_data_tool/config/base.yaml
+++ b/asf_mission_data_tool/config/base.yaml
@@ -40,10 +40,38 @@ dataset:
     versions:
       - file_bronze:
           - s3://asf-mission-data-tool/bronze/energy_price_cap_levels/Annex_9_-_Levelisation_allowance_methodology_and_levelised_cap_levels_v1.4.xlsx
+        file_silver:
+          - s3://asf-mission-data-tool/silver/energy_price_cap_levels/November_2024/Annex_9_-_Levelisation_allowance_methodology_and_levelised_cap_levels_v1.4_1c_Consumption_adjusted_levels.parquet
         file_url:
           - https://www.ofgem.gov.uk/sites/default/files/2024-11/Annex_9_-_Levelisation_allowance_methodology_and_levelised_cap_levels_v1.4.xlsx
         page_url: https://www.ofgem.gov.uk/energy-policy-and-regulation/policy-and-regulatory-programmes/energy-price-cap-default-tariff-policy/energy-price-cap-default-tariff-levels
         release_date: "2024-11-22"
+        tables:
+          - dtypes:
+              Consumption: str
+              Fuel: str
+              Payment method: str
+              Price cap period: str
+              Tariff component: str
+              value: float
+            sheet_name: 1c Consumption adjusted levels
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/energy_price_cap_levels/Annex-9-Levelisation-allowance-methodology-and-levelised-cap-levels-v1.5.xlsx
+        file_silver:
+          - s3://asf-mission-data-tool/silver/energy_price_cap_levels/February_2025/Annex-9-Levelisation-allowance-methodology-and-levelised-cap-levels-v1.5_1c_Consumption_adjusted_levels.parquet
+        file_url:
+          - https://www.ofgem.gov.uk/sites/default/files/2025-02/Annex-9-Levelisation-allowance-methodology-and-levelised-cap-levels-v1.5.xlsx
+        page_url: https://www.ofgem.gov.uk/energy-policy-and-regulation/policy-and-regulatory-programmes/energy-price-cap-default-tariff-policy/energy-price-cap-default-tariff-levels
+        release_date: "2025-02-25"
+        tables:
+          - dtypes:
+              Consumption: str
+              Fuel: str
+              Payment method: str
+              Price cap period: str
+              Tariff component: str
+              value: float
+            sheet_name: 1c Consumption adjusted levels
   fuel_poverty_statistics:
     collection_url: https://www.gov.uk/government/collections/fuel-poverty-statistics
     versions:
@@ -58,7 +86,7 @@ dataset:
     versions:
       - file_bronze:
           - s3://asf-mission-data-tool/bronze/future_energy_scenarios/Future Energy Scenarios
-            2024 Data Workbook_V003.xlsx
+            2024 Data Workbook_V005.xlsx
         file_url:
           - https://www.neso.energy/fes-data-workbook-2024
         page_url: https://www.neso.energy/publications/future-energy-scenarios-fes
@@ -68,10 +96,55 @@ dataset:
     versions:
       - file_bronze:
           - s3://asf-mission-data-tool/bronze/heat_pump_deployment_quarterly_statistics/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2024_Q3.xlsx
+        file_silver:
+          - s3://asf-mission-data-tool/silver/heat_pump_deployment_quarterly_statistics/December_2024/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2024_Q3_Table_1_1.parquet
+          - s3://asf-mission-data-tool/silver/heat_pump_deployment_quarterly_statistics/December_2024/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2024_Q3_Table_1_2.parquet
+          - s3://asf-mission-data-tool/silver/heat_pump_deployment_quarterly_statistics/December_2024/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2024_Q3_Table_1_3.parquet
         file_url:
           - https://assets.publishing.service.gov.uk/media/674ddaf51916486d54daf085/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2024_Q3.xlsx
         page_url: https://www.gov.uk/government/statistics/heat-pump-deployment-statistics-september-2024
         release_date: "2024-12-05"
+        tables:
+          - dtypes:
+              All schemes: int
+              Boiler Upgrade Scheme[Note 5]: int
+              Domestic Renewable Heat Incentive[note 11]: int
+              Energy Company Obligation[Note 10]: int
+              Green Homes Grant Voucher Scheme[Note 8]: int
+              Home Upgrade Grant[Note 6]: int
+              Installation quarter [note 4]: str
+              Local Authority Delivery[note 7]: int
+              Non-Domestic Renewable Heat Incentive[Note 12]: int
+              Social Housing Decarbonisation Fund[Note 9]: int
+            sheet_name: Table 1.1
+            skiprows: 5
+          - dtypes:
+              Air source heat pumps [note 13]: int
+              All technologies: int
+              Ground/water source heat pumps [note 13]: int
+              Installation quarter [note 4]: str
+              Unknown technology [note 14]: int
+            sheet_name: Table 1.2
+            skiprows: 5
+          - dtypes:
+              East: int
+              East Midlands: int
+              England: int
+              England and Wales: int
+              Installation quarter [note 4]: str
+              London: int
+              North East: int
+              North West: int
+              Northern Ireland: int
+              Scotland: int
+              South East: int
+              South West: int
+              United Kingdom: int
+              Wales: int
+              West Midlands: int
+              Yorkshire and The Humber: int
+            sheet_name: Table 1.3
+            skiprows: 9
       - file_url: https://assets.publishing.service.gov.uk/media/66f53fee080bdf716392e93f/Heat_pump_deployment_quarterly_statistics_United_Kingdom_June_2024.xlsx
         page_url: https://www.gov.uk/government/statistics/heat-pump-deployment-statistics-june-2024
         release_date: "2024-09-26"
@@ -139,21 +212,153 @@ dataset:
           - https://www.theccc.org.uk/wp-content/uploads/2020/12/The-Sixth-Carbon-Budget-Dataset_v2.xlsx
         page_url: https://www.theccc.org.uk/publication/sixth-carbon-budget/#supporting-information-charts-and-data
         release_date: "2020-12-09"
+        tables:
+          - sheet_name: Buildings additional data
+            skipcols: 1
+            skiprows: 38
+          - dtypes:
+              Metric index: str
+              Scenario: str
+              Region: str
+              Sector: str
+              Amalgamation: str
+              Metric: str
+              Units: str
+              2020: float
+              2021: float
+              2022: float
+              2023: float
+              2024: float
+              2025: float
+              2026: float
+              2027: float
+              2028: float
+              2029: float
+              2030: float
+              2031: float
+              2032: float
+              2033: float
+              2034: float
+              2035: float
+              2036: float
+              2037: float
+              2038: float
+              2039: float
+              2040: float
+              2041: float
+              2042: float
+              2043: float
+              2044: float
+              2045: float
+              2046: float
+              2047: float
+              2048: float
+              2049: float
+              2050: float
+            sheet_name: Raw data
+            skipcols: 1
+            skiprows: 1
   uk_territorial_greenhouse_gas_emissions_statistics:
     collection_url: https://www.gov.uk/government/collections/uk-territorial-greenhouse-gas-emissions-statistics
     versions:
-      - file_bronze:
-          - s3://asf-mission-data-tool/bronze/uk_territorial_greenhouse_gas_emissions_statistics/2023-provisional-emissions-data-tables.xlsx
-        file_url:
+      - file_url:
           - https://assets.publishing.service.gov.uk/media/660305b1c34a860011be75f2/2023-provisional-emissions-data-tables.xlsx
         page_url: https://www.gov.uk/government/statistics/provisional-uk-greenhouse-gas-emissions-national-statistics-2023
         release_date: "2024-03-28"
-      - file_url:
+      - file_bronze:
+          - s3://asf-mission-data-tool/bronze/uk_territorial_greenhouse_gas_emissions_statistics/final-greenhouse-gas-emissions-tables-2022.xlsx
+          - s3://asf-mission-data-tool/bronze/uk_territorial_greenhouse_gas_emissions_statistics/final-greenhouse-gas-emissions-end-user-tables-2022.xlsx
+          - s3://asf-mission-data-tool/bronze/uk_territorial_greenhouse_gas_emissions_statistics/sic-final-greenhouse-gas-emissions-tables-2022.xlsx
+        file_silver:
+          - s3://asf-mission-data-tool/silver/uk_territorial_greenhouse_gas_emissions_statistics/February_2024/final-greenhouse-gas-emissions-tables-2022_1_2.parquet
+          - s3://asf-mission-data-tool/silver/uk_territorial_greenhouse_gas_emissions_statistics/February_2024/final-greenhouse-gas-emissions-tables-2022_7_1.parquet
+        file_url:
           - https://assets.publishing.service.gov.uk/media/65ff114a65ca2ffef17da7a6/final-greenhouse-gas-emissions-tables-2022.xlsx
           - https://assets.publishing.service.gov.uk/media/66044b8cf9ab410011eea42d/final-greenhouse-gas-emissions-end-user-tables-2022.xlsx
           - https://assets.publishing.service.gov.uk/media/667bec4297ea0c79abfe4c72/sic-final-greenhouse-gas-emissions-tables-2022.xlsx
         page_url: https://www.gov.uk/government/statistics/final-uk-greenhouse-gas-emissions-national-statistics-1990-to-2022
         release_date: "2024-02-06"
+        tables:
+          - dtypes:
+              "1990": float
+              "1991": float
+              "1992": float
+              "1993": float
+              "1994": float
+              "1995": float
+              "1996": float
+              "1997": float
+              "1998": float
+              "1999": float
+              "2000": float
+              "2001": float
+              "2002": float
+              "2003": float
+              "2004": float
+              "2005": float
+              "2006": float
+              "2007": float
+              "2008": float
+              "2009": float
+              "2010": float
+              "2011": float
+              "2012": float
+              "2013": float
+              "2014": float
+              "2015": float
+              "2016": float
+              "2017": float
+              "2018": float
+              "2019": float
+              "2020": float
+              "2021": float
+              "2022": float
+              TES Category: str
+              TES Sector: str
+              TES Subsector: str
+            file_url: https://assets.publishing.service.gov.uk/media/65ff114a65ca2ffef17da7a6/final-greenhouse-gas-emissions-tables-2022.xlsx
+            sheet_name: "1.2"
+            skiprows: 6
+          - dtypes:
+              "1990": float
+              "1991": float
+              "1992": float
+              "1993": float
+              "1994": float
+              "1995": float
+              "1996": float
+              "1997": float
+              "1998": float
+              "1999": float
+              "2000": float
+              "2001": float
+              "2002": float
+              "2003": float
+              "2004": float
+              "2005": float
+              "2006": float
+              "2007": float
+              "2008": float
+              "2009": float
+              "2010": float
+              "2011": float
+              "2012": float
+              "2013": float
+              "2014": float
+              "2015": float
+              "2016": float
+              "2017": float
+              "2018": float
+              "2019": float
+              "2020": float
+              "2021": float
+              "2022": float
+              TES Category: str
+              TES Sector: str
+              TES Subsector: str
+            file_url: https://assets.publishing.service.gov.uk/media/66044b8cf9ab410011eea42d/final-greenhouse-gas-emissions-end-user-tables-2022.xlsx
+            sheet_name: "7.1"
+            skiprows: 6
   welsh_housing_conditions_survey:
     collection_url: https://www.gov.wales/welsh-housing-conditions-survey
     versions:

--- a/asf_mission_data_tool/config/base.yaml
+++ b/asf_mission_data_tool/config/base.yaml
@@ -440,6 +440,44 @@ dataset:
     collection_url: https://www.gov.uk/government/collections/heat-pump-deployment-statistics
     versions:
       - file_bronze:
+          - s3://asf-mission-data-tool/bronze/heat_pump_deployment_quarterly_statistics/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2025_Q1.xlsx
+        file_silver:
+          - s3://asf-mission-data-tool/silver/heat_pump_deployment_quarterly_statistics/June_2025/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2025_Q1_Table_1_1.parquet
+          - s3://asf-mission-data-tool/silver/heat_pump_deployment_quarterly_statistics/June_2025/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2025_Q1_Table_1_2.parquet
+          - s3://asf-mission-data-tool/silver/heat_pump_deployment_quarterly_statistics/June_2025/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2025_Q1_Table_1_3.parquet
+        file_url:
+          - https://assets.publishing.service.gov.uk/media/6839900f9c65cc8cdbae65ae/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2025_Q1.xlsx
+        page_url: https://www.gov.uk/government/statistics/heat-pump-deployment-statistics-march-2025
+        release_date: "2025-06-05"
+        tables:
+          - dtypes:
+              end_of_quarter: datetime64[ns]
+              government_scheme: str
+              installation_quarter: str
+              installations: int64
+              start_of_quarter: datetime64[ns]
+              year: Int64
+            sheet_name: Table 1.1
+            skiprows: 5
+          - dtypes:
+              end_of_quarter: datetime64[ns]
+              installation_quarter: str
+              installations: int64
+              start_of_quarter: datetime64[ns]
+              technology_type: str
+              year: Int64
+            sheet_name: Table 1.2
+            skiprows: 5
+          - dtypes:
+              end_of_quarter: datetime64[ns]
+              installation_quarter: str
+              installations: int64
+              region: str
+              start_of_quarter: datetime64[ns]
+              year: Int64
+            sheet_name: Table 1.3
+            skiprows: 9
+      - file_bronze:
           - s3://asf-mission-data-tool/bronze/heat_pump_deployment_quarterly_statistics/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2024_Q4.xlsx
         file_silver:
           - s3://asf-mission-data-tool/silver/heat_pump_deployment_quarterly_statistics/March_2025/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2024_Q4_Table_1_1.parquet

--- a/asf_mission_data_tool/getters/bronze_to_silver_transformations.py
+++ b/asf_mission_data_tool/getters/bronze_to_silver_transformations.py
@@ -1,0 +1,1314 @@
+import re
+import pandas as pd
+import logging
+
+from sklego.pandas_utils import log_step
+from typing import Dict, Optional, List, Any
+
+"""
+Set up logger
+"""
+
+logger = logging.getLogger(__name__)  # Module-level logger
+
+
+def set_logger(file_path: str):
+    """Sets up the logger to write logs to a file."""
+    logger.setLevel(logging.DEBUG)
+    file_handler = logging.FileHandler(file_path, mode="w")
+    file_handler.setLevel(logging.DEBUG)
+    fmt_file = "%(asctime)s - %(levelname)s - %(message)s"
+    file_formatter = logging.Formatter(fmt_file)
+    file_handler.setFormatter(file_formatter)
+    logger.addHandler(file_handler)
+
+
+def log_decorator(fn):
+    """A decorator that applies the log_step decorator to the given function with specific logging options."""
+    return log_step(time_taken=False, names=True, dtypes=True, print_fn=logger.info)(fn)
+
+
+"""
+Reshaping
+"""
+
+
+@log_decorator
+def melt_dataframe(
+    dataframe: pd.DataFrame,
+    table_name: str,
+    id_vars: List,
+    value_name: str,
+    var_name: Optional[str] = None,
+    value_vars: Optional[List] = None,
+) -> pd.DataFrame:
+    """
+    Transforms a given dataframe from wide format to long format.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+        _Dataframe to be melted.
+    table_name : str
+        Name of table, corresponding to the sheet name in the source Excel file (used as an identifier for log statements).
+    id_vars : List
+        List of columns to keep fixed as identifiers.
+    var_name : str
+        Name of new column that will store variable names.
+    value_name : str
+        Name of new column that will store values.
+
+    Returns
+    -------
+    pd.DataFrame
+        Transformed dataframe in long format.
+
+    Raises
+    ------
+    KeyError
+        If any of `id_vars` or columns to be melted do not exist in the given dataframe.
+    """
+    try:
+        if value_vars:
+            dataframe_long = dataframe.melt(
+                id_vars=id_vars, value_vars=value_vars, value_name=value_name
+            )
+        else:
+            dataframe_long = dataframe.melt(
+                id_vars=id_vars, var_name=var_name, value_name=value_name
+            )
+    except KeyError as e:
+        raise KeyError(
+            f"One of the specified 'id_vars' or columns to melt does not exist in {table_name}: {e}"
+        )
+    return dataframe_long
+
+
+"""
+Final checks and assertions
+"""
+
+
+@log_decorator
+def check_missing_values(
+    dataframe: pd.DataFrame,
+    table_name: str,
+) -> pd.DataFrame:
+    """Checks for missing values in a given dataframe and raises an error if any are found.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+        Dataframe to check for missing values.
+    table_name : str
+        Name of table, corresponding to the sheet name in the source Excel file (used as an identifier for log statements).
+
+    Returns
+    -------
+    pd.DataFrame: Original dataframe if no missing values are found.
+
+
+    Raises
+    ------
+    ValueError
+        If dataframe contains missing (null) values.
+    """
+
+    if dataframe.isnull().values.any():
+        raise ValueError(f"Error: {table_name} contains missing values.")
+    return dataframe
+
+
+@log_decorator
+def assert_dtypes(
+    dataframe: pd.DataFrame, table_name: str, expected_dtypes: Dict
+) -> pd.DataFrame:
+    """
+    Ensures that specified columns in a given dataframe have the expected data types.
+
+    This function checks whether each column in `expected_dtypes` exists in the dataframe and whether its data type matches the expected type.
+    If a column in missing, a `KeyError` is raised. If a column's data type does not match, an attempt is made to cast it to the expected type.
+    If casting fails, a `ValueError` is raised.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+        Dataframe to check and enforce data types.
+    table_name : str
+        Name of table, corresponding to the sheet name in the source Excel file (used as an identifier for log statements).
+    expected_dtypes : Dict
+        Dictionary mapping column names to expected data types.
+
+    Returns
+    -------
+    pd.DataFrame: Dataframe with enforced data types.
+
+    Raises
+    ------
+    KeyError
+        If a column expected in `expected_dtypes` is missing from dataframe.
+    ValueError
+        If a column cannot be cast to the expected data type.
+    """
+
+    for col, dtype in expected_dtypes.items():
+
+        if col not in dataframe.columns:
+            raise KeyError(
+                (
+                    f"Expected column '{col}' not found in the dataframe for table '{table_name}'"
+                )
+            )
+        if dataframe[col].dtype != dtype:
+            try:
+                dataframe[col] = dataframe[col].astype(dtype)
+            except ValueError as e:
+                raise ValueError(
+                    f"Unable to cast column '{col}' to type '{dtype}' in table '{table_name}'"
+                ) from e
+    return dataframe
+
+
+"""
+Dropping rows and columns
+"""
+
+
+@log_decorator
+def drop_duplicate_rows(
+    dataframe: pd.DataFrame,
+    table_name: str,
+    consider_columns: list[str] = None,
+    keep: str = "first",
+) -> pd.DataFrame:
+    """
+    Drops duplicated rows, keeps first occurrence.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Dataframe from which rows will be dropped.
+    table_name : str
+        Name of table, corresponding to the sheet name in the source Excel file (used as an identifier for log statements).
+    consider_columns : list[str]
+        A list of columns to consider for identifying duplicates, default is all columns.
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe with duplicate rows dropped.
+    """
+    dataframe = dataframe.drop_duplicates(subset=consider_columns, keep=keep)
+    return dataframe
+
+
+@log_decorator
+def drop_row(
+    dataframe: pd.DataFrame, table_name: str, index_list_to_drop: list
+) -> pd.DataFrame:
+    """
+    Drops specified rows from a given dataframe by their index.
+
+    This function removes the rows from the dataframe that are specified in `index_list_to_drop`.
+    After dropping the rows, the index is reset.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Dataframe from which rows will be dropped.
+    table_name : str
+        Name of table, corresponding to the sheet name in the source Excel file (used as an identifier for log statements).
+    index_list_to_drop : list
+        A list of indices (row numbers) to drop from the dataframe.
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe with specified rows dropped and index reset.
+    """
+    dataframe = dataframe.drop(index_list_to_drop).reset_index(drop=True)
+    return dataframe
+
+
+@log_decorator
+def drop_nan_rows(
+    dataframe: pd.DataFrame, table_name: str, threshold: int
+) -> pd.DataFrame:
+    """Drops rows from a given dataframe that contain NaN values; a row will only be dropped
+    if it contains over a threshold number of non-NaN values, e.g. threshold of 2 will ensure
+    that kept rows will have at least 2 non-NaN values.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+        Dataframe from which rows with NaN values will be dropped.
+    table_name : str
+        Name of table, corresponding to the sheet name in the source Excel file (used as an identifier for log statements).
+    threshold : int
+        Require that many non-NA values.
+
+    Returns
+    -------
+    pd.DataFrame
+        _description_
+    """
+    dataframe = dataframe.dropna(axis="rows", thresh=threshold)
+    return dataframe
+
+
+@log_decorator
+def drop_nan_columns(dataframe: pd.DataFrame, table_name: str) -> pd.DataFrame:
+    """Drops columns from a given dataframe that contain only NaN values.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+        Dataframe from which columns with all NaN values will be dropped.
+    table_name : str
+        Name of table, corresponding to the sheet name in the source Excel file (used as an identifier for log statements).
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe with columns containing only NaN values removed.
+    """
+    dataframe = dataframe.dropna(axis="columns", how="all")
+    return dataframe
+
+
+@log_decorator
+def drop_header_field_rows(
+    dataframe: pd.DataFrame, table_name: str, column_list: list
+) -> pd.DataFrame:
+    """
+    Removes rows from a DataFrame where column names appear as repeated values.
+
+    This function is useful for cleaning data where header rows are
+    included multiple times within the table. It checks if any value in the
+    specified columns matches the column name and removes such rows.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+        Dataframe to be cleaned.
+    table_name : str
+        Name of table, corresponding to the sheet name in the source Excel file (used as an identifier for log statements).
+    column_list : list
+        List of column names to check for repeated header rows.
+
+    Returns
+    -------
+    pd.DataFrame
+        Cleaned dataframe with repeated header rows removed.
+    """
+    masks = []
+    for column_name in column_list:
+        masks.append(dataframe[column_name] == column_name)
+    return dataframe[~pd.concat(masks, axis=1).any(axis=1)]
+
+
+@log_decorator
+def filter_dataframe_on_column(
+    dataframe: pd.DataFrame, table_name: str, column_name: str, filter: Any
+) -> pd.DataFrame:
+    """
+    Filters dataframe based on specific column and value.
+
+    This function filters the dataframe by keeping only the rows where value in the specified column matches
+    the provided filter value.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+        Dataframe to be filtered.
+    table_name : str
+        Name of table, corresponding to the sheet name in the source Excel file (used as an identifier for log statements).
+    column_name : str
+        Name of column to filter on.
+    filter : Any
+        Value to filter by. Rows where the column value matches this filter will be retained.
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe containing only the rows where the column value matches the filter.
+    """
+    return dataframe[dataframe[column_name] == filter]
+
+
+"""
+Addressing missing values
+"""
+
+
+@log_decorator
+def forward_fill_nan_by_row(
+    dataframe: pd.DataFrame,
+    table_name: str,
+    row_index: int = 0,
+    fill_header: bool = False,
+) -> pd.DataFrame:
+    """
+    Performs forward fill on NaN values row-wise for a specified row in a given dataframe.
+    Optionally, fills missing values in the header row (column names).
+
+    This function replaces NaN values in a specific row using forward fill,
+    which propagates the last valid value forward along the row. If NaNs
+    appear at the beginning of the row, they will remain unchanged.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+        Dataframe containing data to be forward-filled row-wise.
+    table_name : str
+        Name of table, corresponding to the sheet name in the source Excel file
+        (used as an identifier for log statements).
+    row_index : int
+        Index of the row to apply forward fill. Ignored if `fill_header` is True.
+    fill_header : bool, optional
+        If True, forward fill missing values in the column headers instead of a specific row.
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe with forward-filled values for the specified row or headers.
+
+    Raises
+    ------
+    KeyError
+        If the dataframe is empty or the row index is out of bounds.
+
+    Example
+    -------
+    df = pd.DataFrame({
+        "A": [1, None, 3],
+        "B": [None, 2, None],
+        "C": [4, None, 6]
+    })
+    forward_fill_nan_by_row(df, "ExampleTable", 1)
+
+    # Result:
+    #      A    B  C
+    # 0  1.0  1.0  4
+    # 1  NaN  2.0  2
+    # 2  3.0  3.0  6
+
+    # Forward filling headers:
+    df.columns = [None, "B", None]
+    df = forward_fill_nan_by_row(df, "ExampleTable", 0, fill_header=True)
+    # Result:
+    # Columns: [None, "B", "B"]
+    """
+
+    if fill_header:
+        dataframe.columns = dataframe.columns.to_series().ffill()
+    else:
+        if row_index not in dataframe.index:
+            raise KeyError(f"Row index {row_index} not found in table '{table_name}'.")
+        dataframe.loc[row_index] = dataframe.loc[row_index].ffill()
+
+    return dataframe
+
+
+@log_decorator
+def forward_fill_nan_by_column(
+    dataframe: pd.DataFrame, table_name: str, column_name: str
+) -> pd.DataFrame:
+    """
+    Performs forward fill on NaN values in a specified column of a given dataframe.
+
+    this function replaces NaN values in the given column using forward fill which propagates the last valid value forward. If NaNs appear at the beginning of the column, they will remain unchanged.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+        Dataframe containing column to be filled.
+    table_name : str
+        Name of table, corresponding to the sheet name in the source Excel file (used as an identifier for log statements).
+    column_name : str
+        Name of column where NaN values should be forward-filled.
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe with forward-filled values in specified column.
+
+    Raises
+    ------
+    KeyError
+        If any of `id_vars` or columns to be melted do not exist in the given dataframe.
+
+    """
+    if column_name not in dataframe.columns:
+        raise KeyError(f"Column '{column_name}' not found in table '{table_name}'.")
+
+    dataframe[column_name] = dataframe[column_name].ffill()
+    return dataframe
+
+
+@log_decorator
+def forward_backward_fill_nan_by_column(
+    dataframe: pd.DataFrame, table_name: str, column_name: str, limit: int
+) -> pd.DataFrame:
+    """Performs forward and backward fill of NaN values in specified column of given dataframe,
+    within a maximum number of consecutive NaN values (specified by limit).
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+        Dataframe containing column to be filled.
+    table_name : str
+        Name of table, corresponding to the sheet name in the source Excel file (used as an identifier for log statements).
+    column_name : str
+        Name of column where NaN values to be filled.
+    limit : int
+        Maximum number of consecutive NaN values to be filled.
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe with filled values in specified column.
+
+    Raises
+    ------
+    KeyError
+        If any of `id_vars` or columns to be melted do not exist in the given dataframe.
+    """
+
+    if column_name not in dataframe.columns:
+        raise KeyError(f"Column '{column_name}' not found in table '{table_name}'.")
+
+    dataframe[column_name] = (
+        dataframe[column_name].ffill(limit=limit).bfill(limit=limit)
+    )
+    return dataframe
+
+
+@log_decorator
+def replace_nan_in_column(
+    dataframe: pd.DataFrame, table_name: str, column_name: str, value: Any
+) -> pd.DataFrame:
+    """
+    Replaces NaN values in a specified column with a given value.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+        Dataframe with column to be modified.
+    table_name : str
+        Name of table, corresponding to the sheet name in the source Excel file (used as an identifier for log statements).
+    column_name : str
+        Name of column where NaN values will be replaced.
+    value : Any
+        Value to replace NaN values with.
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe with NaN values in specified column replaced with the given value.
+    """
+    dataframe[column_name] = dataframe[column_name].mask(
+        dataframe[column_name].isna(), value
+    )
+    return dataframe
+
+
+"""
+Modifying column names or values
+"""
+
+
+@log_decorator
+def convert_year_column_to_int(
+    dataframe: pd.DataFrame, table_name: str, year_column_name: str
+) -> pd.DataFrame:
+    """
+    Converts a specified year column in the Dataframe to the integer data type.
+
+    This function attempts to convert the specified column to the integer data type (`pd.Int64Dtype()`),
+    which allows for handling of missing values as `NaN` while keeping the column's type as integer.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+        Dataframe containing the column to be converted.
+    table_name : str
+        Name of table, corresponding to the sheet name in the source Excel file (used as an identifier for log statements).
+    year_column_name : str
+        Name of column containing values to be converted.
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe with specified column converted to integer type.
+    """
+    dataframe[year_column_name] = dataframe[year_column_name].astype(pd.Int64Dtype())
+    return dataframe
+
+
+@log_decorator
+def rename_columns(
+    dataframe: pd.DataFrame, table_name: str, column_map: Dict
+) -> pd.DataFrame:
+    """
+    Renames columns in given dataframe based on mapping provided in `column_map`, where keys are current column
+    names and values are new names for those columns.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+        Dataframe with columns to be renamed.
+    table_name : str
+        Name of table, corresponding to the sheet name in the source Excel file (used as an identifier for log statements).
+    column_map : Dict
+        Dictionary where keys are current column names and values are the new names.
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe with columns renamed as per provided mapping.
+    """
+    dataframe = dataframe.rename(columns=column_map)
+    return dataframe
+
+
+@log_decorator
+def convert_to_nan(
+    dataframe: pd.DataFrame, column_name: str, to_replace: str, table_name: str
+) -> pd.DataFrame:
+    """
+    Converts specified values in a column to NaN.
+
+    This function replaces occurrences of the specified `to_replace` value
+    in the given column with `NaN` and converts the column to a numeric type.
+    Any invalid conversions are coerced to NaN.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Dataframe containing the column to modify.
+    column_name : str
+        Name of column where values should be replaced.
+    to_replace : str
+        Value in column to replace with NaN.
+    table_name : str
+        Name of table, corresponding to the sheet name in the source Excel file (used as an identifier for log statements).
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe with specified values replaced by NaN, and column converted to numeric type.
+    """
+    dataframe[column_name] = pd.to_numeric(
+        dataframe[column_name].replace(to_replace, None), errors="coerce"
+    )
+    return dataframe
+
+
+@log_decorator
+def extract_substring_in_column(
+    dataframe: pd.DataFrame,
+    table_name: str,
+    separator: str,
+    column_name: str,
+    segment_to_extract: int,
+) -> pd.DataFrame:
+    """
+    Extracts a substring from a column based on a specified separator.
+
+    This function splits the values in the specified column at the provided `separator` and extracts the substring
+    at the position specified by `segment_to_extract`. It updates the column with the extracted substrings.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+        Dataframe containing the column to process.
+    table_name : str
+        Name of table, corresponding to the sheet name in the source Excel file (used as an identifier for log statements).
+    separator : str
+        Separator used to split the values in the column.
+    column_name : str
+        Name of column where substring will be extracted from.
+    segment_to_extract : int
+        Index of segment to extract, where 0 is the first.
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe with specified column updated with extracted substrings.
+    """
+    dataframe[column_name] = dataframe[column_name].apply(
+        lambda x: x.split(separator)[segment_to_extract]
+    )
+    return dataframe
+
+
+@log_decorator
+def replace_value_in_column(
+    dataframe: pd.DataFrame,
+    table_name: str,
+    column_name: str,
+    replaced_value: Any,
+    replacement_value: Any,
+) -> pd.DataFrame:
+    """
+    Replaces a specified value in a column with a new value.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+        Dataframe with column to be modified.
+    table_name : str
+        Name of table, corresponding to the sheet name in the source Excel file (used as an identifier for log statements).
+    column_name : str
+        Name of column with values to be replaced.
+    replaced_value : Any
+        Value to be replaced.
+    Replacement_value : Any
+        Value to replace the `replaced_value`.
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe with replaced values in specified column.
+
+    """
+    dataframe[column_name] = dataframe[column_name].mask(
+        dataframe[column_name] == replaced_value, replacement_value
+    )
+    return dataframe
+
+
+@log_decorator
+def forward_fill_unnamed_columns(
+    dataframe: pd.DataFrame, table_name: str
+) -> pd.DataFrame:
+    dataframe.columns = (
+        dataframe.columns.to_series()
+        .mask(lambda x: x.str.startswith("Unnamed"))
+        .ffill()
+    )
+    return dataframe
+
+
+@log_decorator
+def remove_line_break_chars(
+    dataframe: pd.DataFrame, table_name: str, column_to_clean: str
+) -> pd.DataFrame:
+    dataframe[column_to_clean] = dataframe[column_to_clean].replace(
+        r"\n", " ", regex=True
+    )
+    return dataframe
+
+
+@log_decorator
+def remove_special_chars(
+    dataframe: pd.DataFrame, table_name: str, column_to_clean: str, char_to_remove: str
+) -> pd.DataFrame:
+    dataframe[column_to_clean] = dataframe[column_to_clean].replace(
+        char_to_remove, "", regex=True
+    )
+    return dataframe
+
+
+@log_decorator
+def trim_whitespace(dataframe: pd.DataFrame, table_name: str) -> pd.DataFrame:
+    dataframe = dataframe.map(lambda x: x.strip() if isinstance(x, str) else x)
+    return dataframe
+
+
+"""
+Adding new columns or rows
+"""
+
+
+@log_decorator
+def add_constant_column(
+    dataframe: pd.DataFrame, table_name: str, column_name: str, constant_value: Any
+) -> pd.DataFrame:
+    """
+    Adds a new column with a constant value to a given dataframe.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+        Dataframe to which the new column will be added.
+    table_name : str
+        Name of table, corresponding to the sheet name in the source Excel file (used as an identifier for log statements).
+    column_name : str
+        Name of new column to be added.
+    constant_value : Any
+        Value to assign to the new column for all rows.
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe with new column added.
+    """
+    dataframe[column_name] = constant_value
+    return dataframe
+
+
+"""
+Specific to DESNZ Heat Pump Deployment Quarterly Statistics
+"""
+
+
+@log_decorator
+def standardise_column_names(
+    dataframe: pd.DataFrame,
+    table_name: str,
+) -> pd.DataFrame:
+    """
+    Standardises column names across all tables by applying specific formatting rules.
+
+    This function checks the column names of the given dataframe and standardises them according to predefined rules
+    for different tables. It performs checks for specific substrings in the column names and applies transformations
+    such as removing newline characters and replacing certain substrings.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+        Dataframe with column names to be standardised.
+    table_name : str
+        Name of table, corresponding to the sheet name in the source Excel file (used as an identifier for log statements).
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe with standardised column names.
+
+    Raises
+    ------
+    ValueError
+        If column names do not meet the expected format for the given table name.
+    """
+
+    if table_name == "Table 1.1":
+
+        # Check if format of column names are as expected by this function
+        if not dataframe.columns.str.contains("\n").any():
+            raise ValueError(
+                "Expected newline characters in column names for Table 1.1"
+            )
+        if not dataframe.columns.str.contains("Of which:").any():
+            raise ValueError("Expected 'Of which:' in column names for Table 1.1")
+        if not dataframe.columns.str.contains(
+            "Total: Government-supported heat pump installations"
+        ).any():
+            raise ValueError(
+                "Expected 'Total: Government-supported heat pump installations' in column names for Table 1.1"
+            )
+
+        dataframe.columns = (
+            dataframe.columns.str.strip()
+            .str.replace("\n", "", regex=True)
+            .str.replace("Of which:", "", regex=False)
+            .str.replace(
+                "Total: Government-supported heat pump installations",
+                "All schemes",
+                regex=False,
+            )
+        )
+
+    elif table_name == "Table 1.2":
+
+        # Check if format of column names are as expected by this function
+        if not dataframe.columns.str.contains("\n").any():
+            raise ValueError(
+                "Expected newline characters in column names for Table 1.2"
+            )
+        if not dataframe.columns.str.contains(
+            "Government-supported heat pump installations:"
+        ).any():
+            raise ValueError(
+                "Expected 'Government-supported heat pump installations:' in column names for Table 1.2"
+            )
+
+        dataframe.columns = (
+            dataframe.columns.str.strip()
+            .str.replace("\n", "", regex=True)
+            .str.replace(
+                "Government-supported heat pump installations:", "", regex=False
+            )
+            .str.capitalize()
+        )
+    elif table_name == "Table 1.3":
+        pass
+    else:
+        raise ValueError(
+            "Sheet name does not correspond to a table in the dataset file."
+        )
+    return dataframe
+
+
+@log_decorator
+def expand_quarter_string(dataframe: pd.DataFrame, table_name: str) -> pd.DataFrame:
+    """
+    Converts a quarter string (e.g., "2018 Q1: January to March") into structured components:
+    quarter, year, start date, and end date. Tailored to the DESNZ Heat Pump Deployment Quarterly Statistics data tables.
+
+    Parameters
+    ----------
+    quarter_str : str
+        A string representing a year and quarter in the format "YYYY QX" (e.g., "2018 Q1") or "Unknown".
+    table_name : str
+        Name of table, corresponding to the sheet name in the source Excel file (used as an identifier for log statements).
+
+    Returns
+    -------
+    tuple[str, str, Optional[pd.Timestamp], Optional[pd.Timestamp]]
+        - Quarter (e.g., "Q1", "Q2", "Q3", "Q4") or "Unknown".
+        - Year as a string or "Unknown".
+        - Start date of the quarter as a pandas Timestamp (or None if "Unknown").
+        - End date of the quarter as a pandas Timestamp (or None if "Unknown").
+    """
+
+    def convert_quarter_string(
+        quarter_str: str,
+    ) -> tuple[str, str, Optional[pd.Timestamp], Optional[pd.Timestamp]]:
+
+        # Validate that input string is in expected format
+        pattern = r"^\d{4} Q[1-4]: .+"
+        if quarter_str != "Unknown" and not re.match(pattern, quarter_str):
+            raise ValueError(
+                f"Invalid quarter format: {quarter_str}. Expected format 'YYYY QX: <Month range of quarter>'."
+            )
+
+        # Handle Unknown cases
+        if "Unknown" in quarter_str:
+            return "Unknown", pd.NA, None, None
+
+        year, quarter_number = quarter_str.split(" Q")
+        year = int(year)
+        quarter = int(quarter_number[0])
+
+        start_dates = {
+            1: f"{year}-01-01",
+            2: f"{year}-04-01",
+            3: f"{year}-07-01",
+            4: f"{year}-10-01",
+        }
+
+        end_dates = {
+            1: f"{year}-03-31",
+            2: f"{year}-06-30",
+            3: f"{year}-09-30",
+            4: f"{year}-12-31",
+        }
+
+        return (
+            f"Q{quarter}",
+            year,
+            pd.to_datetime(start_dates[quarter]),
+            pd.to_datetime(end_dates[quarter]),
+        )
+
+    dataframe[
+        ["Installation quarter [note 4]", "Year", "Start of quarter", "End of quarter"]
+    ] = dataframe["Installation quarter [note 4]"].apply(
+        lambda x: pd.Series(convert_quarter_string(x))
+    )
+    dataframe["Year"] = dataframe["Year"].astype(pd.Int64Dtype())
+
+    return dataframe
+
+
+"""
+Specific to Energy price cap levels
+"""
+
+
+def _extract_payment_method_tables(
+    df: pd.DataFrame, payment_method: str
+) -> pd.DataFrame:
+    """
+    Extracts a specific payment method table from a master dataframe.
+    Tailored to the Ofgem Annex 9 energy price cap tariff data tables.
+
+    This function identifies and isolates a table corresponding to a specific payment method
+    ("Other Payment Method", "Standard Credit", "PPM") in the dataframe. It extracts a subset of rows
+    and columns based on the payment method and cleans up the table by forward filling missing column names,
+    dropping fully empty rows and columns, and resetting the index.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Dataframe containing all payment method tables.
+    payment_method : str
+        The payment method for which the table should be extracted. Valid options are:
+        - "Other Payment Method"
+        - "Standard Credit"
+        - "PPM"
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe containing the extracted payment method table with unnecessary rows
+        and columns removed, and missing column names forward-filled.
+    """
+
+    payment_method_number = {"Other Payment Method": 1, "Standard Credit": 3, "PPM": 5}
+
+    # Get row index range
+    start_index = df.index[df["Unnamed: 1"] == payment_method].tolist()[0]
+
+    # Only dual fuel table has Total inc VAT row
+    dual_fuel_header_column = df.columns[
+        df.apply(
+            lambda col: col.astype(str).str.contains("Dual fuel (implied)", regex=False)
+        ).any()
+    ][0]
+    end_index = df.index[df[dual_fuel_header_column] == "Total inc VAT"].tolist()[
+        payment_method_number.get(payment_method)
+    ]
+
+    # Isolate payment method tables
+    payment_method_df = df.iloc[start_index : end_index + 1, :]
+
+    # Forward fill empty column names
+    pd.set_option("future.no_silent_downcasting", True)
+    payment_method_df = payment_method_df.ffill(axis="columns").infer_objects(
+        copy=False
+    )
+
+    # Drop fully empty rows and columns
+    payment_method_df = (
+        payment_method_df.dropna(axis="index", how="all")
+        .dropna(axis="columns", how="all")
+        .reset_index(drop=True)
+    )
+
+    return payment_method_df
+
+
+def _shape_fuel_tables_to_tidy(
+    payment_method_df: pd.DataFrame, payment_method: str, fuel: str
+) -> pd.DataFrame:
+    """
+    Transforms a fuel table for a specific payment method into a tidy format.
+
+    This function extracts columns related to the specified fuel type from the given dataframe, identifies rows corresponding to "Nil consumption"
+    and "Typical consumption", and reshapes the data into a tidy format by melting the consumption and tariff component information.
+    It then concatenates the reshaped data for "Nil consumption" and "Typical consumption" into a single dataframe.
+
+    Parameters
+    ----------
+    payment_method_df : pd.DataFrame
+        Dataframe containing data for a given payment method. Output of _extract_payment_method_tables.
+    payment_method : str
+        Payment method, valid options are:
+        - "Other Payment Method"
+        - "Standard Credit"
+        - "PPM"
+    fuel : str
+        Fuel type of interest, valid options are:
+        - "Electricity: Single-Rate Metering Arrangement"
+        - "Electricity: Multi-Register Metering Arrangement"
+        - "Gas"
+        - "Dual fuel (implied)"
+
+    Returns
+    -------
+    pd.DataFrame
+        A tidy DataFrame containing the reshaped data with columns for "Payment method",
+        "Fuel", "Consumption", "Tariff component", and "Price cap period".
+    """
+
+    fuel_columns = []
+    for column in payment_method_df.columns:
+        if payment_method_df[column].str.contains(fuel, na=False, regex=False).any():
+            fuel_columns.append(column)
+    fuel_df = payment_method_df[fuel_columns]
+
+    start_nil_index = fuel_df.index[
+        fuel_df[fuel_columns[0]] == "Nil consumption"
+    ].tolist()[0]
+    start_typical_index = fuel_df.index[
+        fuel_df[fuel_columns[0]] == "Typical consumption"
+    ].tolist()[0]
+
+    # Nil consumption
+    consumption_type = "Nil consumption"
+    fuel_nil_df = fuel_df.iloc[
+        start_nil_index : start_typical_index - 1, :
+    ].reset_index(drop=True)
+    fuel_nil_df.columns = fuel_nil_df.iloc[0]
+    fuel_nil_df = fuel_nil_df.iloc[1:]
+    fuel_nil_df = fuel_nil_df.rename(columns={consumption_type: "Tariff component"})
+    fuel_nil_df["Payment method"] = payment_method
+    fuel_nil_df["Consumption"] = consumption_type
+    fuel_nil_df["Fuel"] = fuel
+
+    fuel_nil_tidy = fuel_nil_df.melt(
+        id_vars=["Payment method", "Fuel", "Consumption", "Tariff component"],
+        var_name="Price cap period",
+    )
+
+    # Typical consumption
+    consumption_type = "Typical consumption"
+    fuel_typical_df = fuel_df.iloc[start_typical_index:, :].reset_index(drop=True)
+    fuel_typical_df.columns = fuel_typical_df.iloc[0]
+    fuel_typical_df = fuel_typical_df.iloc[1:]
+    fuel_typical_df = fuel_typical_df.rename(
+        columns={consumption_type: "Tariff component"}
+    )
+    fuel_typical_df["Payment method"] = payment_method
+    fuel_typical_df["Consumption"] = consumption_type
+    fuel_typical_df["Fuel"] = fuel
+
+    fuel_typical_tidy = fuel_typical_df.melt(
+        id_vars=["Payment method", "Fuel", "Consumption", "Tariff component"],
+        var_name="Price cap period",
+    )
+
+    return pd.concat([fuel_nil_tidy, fuel_typical_tidy]).dropna(
+        subset={"Tariff component"}
+    )
+
+
+@log_decorator
+def convert_tariff_tables_to_tidy(
+    dataframe: pd.DataFrame, table_name: str
+) -> pd.DataFrame:
+    """
+    Converts all tariff tables into tidy format.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Raw dataframe of tariff data from reading entire sheet of Annex 9 Excel file.
+    table_name : str
+        Name of table, corresponding to the sheet name in the source Excel file (used as an identifier for log statements).
+
+
+    Returns
+    -------
+    pd.DataFrame
+        Tidy DataFrame containing the reshaped tariff data, with columns for "Payment method",
+        "Fuel", "Consumption", "Tariff component", and "Price cap period". The data is organized
+        into a long format, with each row representing a unique combination of payment method, fuel,
+        consumption type, and price cap period.
+    """
+    payment_method_tables = {}
+
+    for payment_method in ["Other Payment Method", "Standard Credit", "PPM"]:
+
+        all_fuel_df = pd.DataFrame()
+        for fuel in [
+            "Electricity: Single-Rate Metering Arrangement",
+            "Electricity: Multi-Register Metering Arrangement",
+            "Gas",
+            "Dual fuel (implied)",
+        ]:
+            fuel_df = _shape_fuel_tables_to_tidy(
+                payment_method_df=_extract_payment_method_tables(
+                    dataframe, payment_method
+                ),
+                payment_method=payment_method,
+                fuel=fuel,
+            )
+            all_fuel_df = pd.concat([all_fuel_df, fuel_df])
+
+        payment_method_tables[payment_method] = all_fuel_df
+
+    return pd.concat(payment_method_tables.values(), ignore_index=True)
+
+
+@log_decorator
+def expand_price_cap_period(
+    dataframe: pd.DataFrame, column_name: str, table_name: str
+) -> pd.DataFrame:
+    """
+    Expands a 'Price cap period' column into two separate columns: 'Price cap period start' and 'Price cap period end'.
+
+    This function takes the 'Price cap period' column containing a range (e.g., "Jan 2023 - Dec 2023") and splits it into
+    two separate columns for the start and end date. The month names are converted to full month names (e.g., 'Jan' to 'January'),
+    and the date strings are converted into `datetime` objects.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame containing the data, including a 'Price cap period' column that has a range of dates in string format.
+    column_name : str
+        Name of column containing the price cap period range.
+    table_name : str
+        Name of table, corresponding to the sheet name in the source Excel file (used as an identifier for log statements).
+
+    Returns
+    -------
+    pd.DataFrame
+        A DataFrame with two additional columns: 'Price cap period start' and 'Price cap period end'.
+        These columns contain the start and end dates of the price cap period in `datetime` format.
+
+    Raises
+    ------
+    ValueError
+        If the 'Price cap period' column contains an invalid month format.
+    """
+    dataframe[["Price cap period start", "Price cap period end"]] = dataframe[
+        column_name
+    ].str.split(" - ", expand=True)
+
+    def _convert_to_full_month(month_str):
+        month_map = {
+            "Jan": "January",
+            "Feb": "February",
+            "Mar": "March",
+            "Apr": "April",
+            "May": "May",
+            "Jun": "June",
+            "Jul": "July",
+            "Aug": "August",
+            "Sep": "September",
+            "Oct": "October",
+            "Nov": "November",
+            "Dec": "December",
+            "Sept": "September",
+        }
+
+        if month_str[:-5] in month_map.keys():
+            return month_map[month_str[:-5]] + " " + month_str[-4:]
+        elif month_str[:-5] in month_map.values():
+            return month_str
+        raise ValueError("Invalid month format")
+
+    dataframe["Price cap period start"] = dataframe["Price cap period start"].apply(
+        _convert_to_full_month
+    )
+    dataframe["Price cap period end"] = dataframe["Price cap period end"].apply(
+        _convert_to_full_month
+    )
+
+    dataframe["Price cap period start"] = pd.to_datetime(
+        dataframe["Price cap period start"], format="%B %Y"
+    )
+    dataframe["Price cap period end"] = pd.to_datetime(
+        dataframe["Price cap period end"], format="%B %Y"
+    )
+    return dataframe
+
+
+"""
+Specific to Seventh Carbon Budget
+"""
+
+
+@log_decorator
+def convert_sign_of_abatement(dataframe: pd.DataFrame, table_name: str) -> pd.DataFrame:
+    """
+    Converts the sign of the 'Value' column based on the 'Category' column.
+
+    This function checks the 'Category' column for each row in the dataframe. If the 'Category' is
+    not 'Residual emissions' (i.e. it refers to emissions abatement), it changes the sign of the value in the 'Value' column.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+        Dataframe containing combined residual and abatement emissions data.
+    table_name : str
+        Name of table, corresponding to the sheet name in the source Excel file (used as an identifier for log statements).
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe with adjusted 'Value' column.
+    """
+    dataframe["Value"] = dataframe.apply(
+        lambda row: (
+            row["Value"]
+            if row["Category"] == "Residual emissions"
+            else -abs(row["Value"])
+        ),
+        axis=1,
+    )
+    return dataframe
+
+
+"""
+Specific to UK Territorial Greenhouse Gas Emissions Statistics
+"""
+
+
+@log_decorator
+def fill_sector_category_columns(
+    dataframe: pd.DataFrame,
+    table_name: str,
+    sector_column: str,
+    subsector_column: str,
+    category_column: str,
+) -> pd.DataFrame:
+
+    # Fill subsector column for "total" rows
+    dataframe.loc[
+        dataframe[sector_column].str.contains("total", case=False, na=False),
+        subsector_column,
+    ] = dataframe[sector_column]
+
+    # Fill category column for "total" rows
+    dataframe.loc[
+        dataframe[subsector_column].str.contains("total", case=False, na=False),
+        category_column,
+    ] = "Total"
+    return dataframe
+
+
+"""
+Specific to Energy Consumption in the UK
+"""
+
+
+@log_decorator
+def add_year_column(
+    dataframe: pd.DataFrame,
+    table_name: str,
+    year_column_name: str,
+    existing_year_column_to_duplicate: tuple,
+) -> pd.DataFrame:
+    dataframe[year_column_name] = dataframe[existing_year_column_to_duplicate]
+    return dataframe
+
+
+"""
+Specific to DESNZ Public Attitudes Tracking Survey
+"""
+
+
+@log_decorator
+def expand_wave_season_dates(
+    dataframe: pd.DataFrame, table_name: str, column_name: str
+) -> pd.DataFrame:
+
+    def _get_season_dates(season: str):
+        season_name, year = season.split()
+        year = int(year)
+
+        if season_name.lower() == "winter":
+            start = pd.Timestamp(f"{year}-12-01")
+            end = pd.Timestamp(f"{year + 1}-02-28")
+        elif season_name.lower() == "spring":
+            start = pd.Timestamp(f"{year}-03-01")
+            end = pd.Timestamp(f"{year}-05-31")
+        elif season_name.lower() == "summer":
+            start = pd.Timestamp(f"{year}-06-01")
+            end = pd.Timestamp(f"{year}-08-31")
+        elif season_name.lower() == "autumn":
+            start = pd.Timestamp(f"{year}-09-01")
+            end = pd.Timestamp(f"{year}-11-30")
+        else:
+            raise ValueError(
+                "Invalid season name. Must be one of: 'Winter', 'Spring', 'Summer', 'Autumn'"
+            )
+
+        # Return year, start and end dates
+        return year, start, end
+
+    dataframe[["wave_year", "season_start_date", "season_end_date"]] = dataframe[
+        column_name
+    ].apply(lambda x: pd.Series(_get_season_dates(x)))
+    return dataframe
+
+
+"""
+Specific to English Housing Survey
+"""

--- a/asf_mission_data_tool/getters/data_getters.py
+++ b/asf_mission_data_tool/getters/data_getters.py
@@ -1,0 +1,284 @@
+import requests
+import boto3
+import subprocess
+import toml
+import logging
+import yaml
+from botocore.exceptions import NoCredentialsError, ClientError
+from datetime import datetime
+from typing import Callable, Any, Optional, Dict
+from asf_mission_data_tool import config
+
+# Suppress information level messages from botocore
+logging.getLogger("botocore.credentials").setLevel(logging.ERROR)
+
+
+def _save_provenance_to_toml(func: Callable[..., Any]) -> Callable[..., Any]:
+    """
+    A decorator function that adds provenance metadata to an S3 file upload operation.
+    The following metadata about the downloaded file is captured:
+    - Original file URL
+    - Download date and time
+    - Git user who downloaded the file
+    This function generates a TOML file containing this metadata and uploads it to an S3 bucket.
+    If a TOML file already exists in the bucket, the user is prompted to confirm whether to overwrite it.
+
+    Parameters
+    ----------
+    func : Callable[..., Any]
+        The decorated function that performs the primary operation, such as uploading a file to S3.
+
+    Returns
+    -------
+    Callable[..., Any]
+        The wrapper function that adds metadata handling to the original function.
+
+    Raises
+    -------
+    Exception: If any error occurs during the file upload or metadata generation process.
+
+    """
+
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+
+        # Execute inner function
+        result = func(*args, **kwargs)
+
+        # Extract information from arguments
+        dataset_name = kwargs.get("dataset_name", "")
+        target_url = kwargs.get("target_url", "")
+
+        # Prepare provenance metadata
+        metadata = {
+            "original_file_url": target_url,
+            "download_date_time": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            "downloaded_by_git_user": subprocess.check_output(
+                ["git", "config", "--global", "user.name"]
+            )
+            .strip()
+            .decode("utf-8"),
+        }
+
+        # Convert to TOML format
+        toml_content = toml.dumps(metadata)
+
+        # Define S3 path for .toml file
+        file_name = target_url.split("/")[-1]
+        toml_file_name = file_name.rsplit(".", 1)[0] + ".toml"
+        toml_file_path = f"bronze/{dataset_name}/{toml_file_name}"
+
+        # Upload to S3
+        s3_client = boto3.client("s3")
+
+        # Check if .toml file already exists in S3 bucket
+        try:
+            s3_client.head_object(Bucket="asf-mission-data-tool", Key=toml_file_path)
+            toml_exists = True
+        except ClientError as error:
+            if error.response["Error"]["Code"] == "404":
+                toml_exists = False
+            else:
+                # Raise if other error
+                raise
+
+        # If .toml file exists, prompt user to confirm overwrite
+        if toml_exists:
+            overwrite = input(
+                f"File s3://asf-mission-data-tool/{toml_file_path} already exists. Do you want to overwrite it? (y/n): "
+            )
+            if overwrite.lower() != "y":
+                print("Metadata file not overwritten. Aborting upload.")
+                return  # Abort the function
+
+        # Proceed with uploading .toml file
+        try:
+            s3_client.put_object(
+                Bucket="asf-mission-data-tool", Key=toml_file_path, Body=toml_content
+            )
+            print(
+                f"Provenance metadata saved to s3://asf-mission-data-tool/{toml_file_path}"
+            )
+        except NoCredentialsError:
+            print("Credentials not available.")
+        except Exception as e:
+            print(f"Error uploading metadata file: {e}")
+
+        return result
+
+    wrapper.__name__ = func.__name__
+    wrapper.__doc__ = func.__doc__
+
+    return wrapper
+
+
+@_save_provenance_to_toml
+def save_to_s3_bronze(dataset_name: str, target_url: str) -> str:
+    """
+    Downloads a file from a given URL and uploads it to the S3 bucket "asf-mission-data-tool".
+    This function checks if the file already exists in the S3 bucket:
+    - If the file exists and the size matches, it will ask the user if they want to overwrite it.
+    - If the file exists but the size differs, it will ask the user if they still want to overwrite it.
+    - If the file doesn't exist, it will upload the file.
+    Additionally, it calls the `save_provenance_to_toml` decorator to save metadata about the file in a sidecar .toml file.
+    Parameters
+    ----------
+    dataset_name : str
+        The name of the dataset used for the S3 path; fixed, unique identifier to identify any instance of the dataset.
+    target_url : str
+        The URL of the file to be downloaded and uploaded to S3.
+
+    Returns
+    -------
+    str
+        File path where bronze data has been saved in s3.
+
+    Raises
+    -------
+    Exception: If there are issues downloading the file, uploading to S3, or checking the file's existence.
+
+    """
+
+    # Download target file
+    with requests.get(target_url) as response:
+        if response.status_code == 200:
+            file_content = response.content
+        else:
+            print(f"Failed to download file. Status code: {response.status_code}")
+            return
+
+    # Upload to S3
+    s3_client = boto3.client("s3")
+
+    # Get file name from URL or response headers
+    if "Content-Disposition" in response.headers:
+        content_disposition = response.headers["Content-Disposition"]
+        file_name = content_disposition.split("filename=")[-1].strip('"')
+    else:
+        file_name = target_url.split("/")[-1]
+
+    # Define S3 path for main file
+    main_file_path = f"bronze/{dataset_name}/{file_name}"
+
+    # Check if file already exists in S3 bucket
+    try:
+        response = s3_client.head_object(
+            Bucket="asf-mission-data-tool", Key=main_file_path
+        )
+        # If no ClientError is raised, the file exists
+        file_exists = True
+        existing_file_size = response["ContentLength"]
+    except ClientError as error:
+        # If the ClientError code is 404, the file does not exist
+        if error.response["Error"]["Code"] == "404":
+            file_exists = False
+        else:
+            # Raise if other error
+            raise
+
+    # If main file exists, check if sizes match and prompt user to confirm overwrite
+    if file_exists:
+        local_file_size = len(file_content)
+        if existing_file_size == local_file_size:
+            print(
+                f"File s3://asf-mission-data-tool/{main_file_path} already exists and has the same size."
+            )
+            overwrite = input(f"Do you want to overwrite it? (y/n): ")
+            if overwrite.lower() != "y":
+                print("Main file not overwritten. Aborting upload.")
+                return  # Abort the function
+        else:
+            print(
+                f"File s3://asf-mission-data-tool/{main_file_path} exists, but sizes do not match."
+            )
+            overwrite = input(f"Do you still want to overwrite it? (y/n): ")
+            if overwrite.lower() != "y":
+                print("Main file not overwritten. Aborting upload.")
+                return  # Abort the function
+
+    # Upload main file to S3 if file does not exist or overwrite confirmed
+    try:
+        s3_client.put_object(
+            Bucket="asf-mission-data-tool", Key=main_file_path, Body=file_content
+        )
+        print(
+            f"File uploaded successfully to s3://asf-mission-data-tool/{main_file_path}"
+        )
+    except NoCredentialsError:
+        print("Credentials not available.")
+    except Exception as e:
+        print(f"Error uploading file: {e}")
+
+    return f"s3://asf-mission-data-tool/{main_file_path}"
+
+
+def get_latest_version(dataset_name: str, filter: Optional[str] = None) -> Dict:
+    """Returns the latest version of a dataset instance from config.
+
+    Parameters
+    ----------
+    dataset_name : str
+        Name of dataset; must be a key of dataset in config/base.yaml.
+
+    filter : Optional[str], default None
+        Word to filter file URLs if only interested in gettgin the latest version of one particular category in the dataset.
+
+    Returns
+    -------
+    Dict
+        Dictionary with key-value pairs for dataset release date, file url and page url.
+    """
+    versions = config.get("dataset").get(dataset_name).get("versions")
+
+    if filter:
+        filtered_versions = [
+            version
+            for version in versions
+            if any(filter in url for url in version["file_url"])
+        ]
+        latest_version = max(
+            filtered_versions,
+            key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d"),
+        )
+    else:
+        latest_version = max(
+            versions, key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d")
+        )
+    return latest_version
+
+
+def append_file_bronze_to_latest_version(
+    dataset_name: str,
+    s3_file_path: str,
+    filter: Optional[str] = None,
+) -> None:
+
+    # Load existing config data
+    with open("asf_mission_data_tool/config/base.yaml", "r") as file:
+        all_existing_data = yaml.safe_load(file)
+
+    # Update data
+    dataset_specific_data = all_existing_data.get("dataset", {}).get(dataset_name, {})
+    versions = dataset_specific_data.get("versions", [])
+    if filter:
+        filtered_versions = [
+            version
+            for version in versions
+            if any(filter in url for url in version["file_url"])
+        ]
+        latest_version = max(
+            filtered_versions,
+            key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d"),
+        )
+    else:
+        latest_version = max(
+            versions, key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d")
+        )
+    latest_version["file_bronze"] = s3_file_path
+
+    # Write updated data to .yaml
+    with open("asf_mission_data_tool/config/base.yaml", "w") as file:
+        yaml.dump(all_existing_data, file, default_flow_style=False, sort_keys=True)
+
+    print(
+        f"file_bronze field added to version with release_date {latest_version['release_date']}."
+    )

--- a/asf_mission_data_tool/getters/data_getters.py
+++ b/asf_mission_data_tool/getters/data_getters.py
@@ -7,7 +7,7 @@ import yaml
 import io
 import pandas as pd
 from botocore.exceptions import NoCredentialsError, ClientError
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
 from typing import Callable, Any, Optional, Dict
 from asf_mission_data_tool import config
 
@@ -366,7 +366,8 @@ def save_to_s3_silver(
     subset_id: str,
 ) -> str:
     """Saves a given Pandas DataFrame to the asf_mission_data_tool S3 bucket in parquet format. The file is stored in both
-    the "LATEST" directory and a date-specific archive directory.
+     the LATEST/ directory and a date-specific archive directory. Any existing file in LATEST/ that is older than five minutes
+     is deemed as outdated and then deleted.
 
     Parameters
     ----------
@@ -406,22 +407,29 @@ def save_to_s3_silver(
         )
 
         if "Contents" in existing_files:
-            objects_to_delete = [
-                {"Key": obj["Key"]} for obj in existing_files["Contents"]
-            ]
-            file_paths = [
-                f"s3://{bucket_name}/{obj['Key']}" for obj in existing_files["Contents"]
-            ]
+            objects_to_delete = []
+            file_paths = []
+            five_minutes_ago = datetime.now(timezone.utc) - timedelta(minutes=5)
 
-            # Delete the files
-            s3_client.delete_objects(
-                Bucket=bucket_name, Delete={"Objects": objects_to_delete}
-            )
+            for obj in existing_files["Contents"]:
+                last_modified = obj["LastModified"]
 
-            # Print the deleted file paths
-            print(f"Deleted {len(objects_to_delete)} files from {latest_prefix}:")
-            for path in file_paths:
-                print(f"  - {path}")
+                if (
+                    last_modified < five_minutes_ago
+                ):  # Only delete if file is older than five minutes
+                    objects_to_delete.append({"Key": obj["Key"]})
+                    file_paths.append(f"s3://{bucket_name}/{obj['Key']}")
+
+            if objects_to_delete:
+                s3_client.delete_objects(
+                    Bucket=bucket_name, Delete={"Objects": objects_to_delete}
+                )
+
+                print(
+                    f"Deleted {len(objects_to_delete)} outdated files from {latest_prefix}:"
+                )
+                for path in file_paths:
+                    print(f"  - {path}")
 
         with io.BytesIO() as parquet_buffer:
 
@@ -433,17 +441,13 @@ def save_to_s3_silver(
                 Key=latest_key,
                 Body=parquet_buffer.getvalue(),
             )
-            print(
-                f"File uploaded successfully to s3://asf-mission-data-tool/{latest_key}"
-            )
+            print(f"File uploaded successfully to s3://{bucket_name}/{latest_key}")
             s3_client.put_object(
                 Bucket=bucket_name,
                 Key=archive_key,
                 Body=parquet_buffer.getvalue(),
             )
-            print(
-                f"File uploaded successfully to s3://asf-mission-data-tool/{archive_key}"
-            )
+            print(f"File uploaded successfully to s3://{bucket_name}/{archive_key}")
     except NoCredentialsError:
         print("Credentials not available.")
 

--- a/asf_mission_data_tool/getters/data_getters.py
+++ b/asf_mission_data_tool/getters/data_getters.py
@@ -390,21 +390,46 @@ def save_to_s3_silver(
     archive_date = pd.to_datetime(main_file_dict.get("release_date")).strftime("%B_%Y")
 
     s3_client = boto3.client("s3")
+    bucket_name = "asf-mission-data-tool"
 
     # Save to LATEST/ and archive date/
+    latest_prefix = f"silver/{dataset_name}/LATEST/"
     latest_key = f"silver/{dataset_name}/LATEST/{file_name}_{subset_id}.parquet"
     archive_key = (
         f"silver/{dataset_name}/{archive_date}/{file_name}_{subset_id}.parquet"
     )
 
-    with io.BytesIO() as parquet_buffer:
+    try:
+        # List all files in the LATEST directory
+        existing_files = s3_client.list_objects_v2(
+            Bucket=bucket_name, Prefix=latest_prefix
+        )
 
-        dataframe.to_parquet(parquet_buffer, engine="pyarrow", index=False)
-        parquet_buffer.seek(0)
+        if "Contents" in existing_files:
+            objects_to_delete = [
+                {"Key": obj["Key"]} for obj in existing_files["Contents"]
+            ]
+            file_paths = [
+                f"s3://{bucket_name}/{obj['Key']}" for obj in existing_files["Contents"]
+            ]
 
-        try:
+            # Delete the files
+            s3_client.delete_objects(
+                Bucket=bucket_name, Delete={"Objects": objects_to_delete}
+            )
+
+            # Print the deleted file paths
+            print(f"Deleted {len(objects_to_delete)} files from {latest_prefix}:")
+            for path in file_paths:
+                print(f"  - {path}")
+
+        with io.BytesIO() as parquet_buffer:
+
+            dataframe.to_parquet(parquet_buffer, engine="pyarrow", index=False)
+            parquet_buffer.seek(0)
+
             s3_client.put_object(
-                Bucket="asf-mission-data-tool",
+                Bucket=bucket_name,
                 Key=latest_key,
                 Body=parquet_buffer.getvalue(),
             )
@@ -412,16 +437,17 @@ def save_to_s3_silver(
                 f"File uploaded successfully to s3://asf-mission-data-tool/{latest_key}"
             )
             s3_client.put_object(
-                Bucket="asf-mission-data-tool",
+                Bucket=bucket_name,
                 Key=archive_key,
                 Body=parquet_buffer.getvalue(),
             )
             print(
                 f"File uploaded successfully to s3://asf-mission-data-tool/{archive_key}"
             )
-        except NoCredentialsError:
-            print("Credentials not available.")
-        except Exception as e:
-            print(f"Error uploading file: {e}")
+    except NoCredentialsError:
+        print("Credentials not available.")
 
-    return f"s3://asf-mission-data-tool/{archive_key}"
+    except Exception as e:
+        print(f"Error uploading file: {e}")
+
+    return f"s3://{bucket_name}/{archive_key}"

--- a/asf_mission_data_tool/getters/data_getters.py
+++ b/asf_mission_data_tool/getters/data_getters.py
@@ -363,6 +363,7 @@ def save_to_s3_silver(
     dataframe: pd.DataFrame,
     dataset_name: str,
     main_file_dict: Dict,
+    file_url_index: int,
     subset_id: str,
 ) -> str:
     """Saves a given Pandas DataFrame to the asf_mission_data_tool S3 bucket in parquet format. The file is stored in both
@@ -377,6 +378,8 @@ def save_to_s3_silver(
         Name of dataset; must be a key of dataset in config/base.yaml.
     main_file_dict : Dict
         Dictionary containing dataset metadata from config/base.yaml.
+    file_url_index : int
+        Index of the target url in the file_url list in main_file_dict; to be used for the s3 file name.
     subset_id : str
         An identifier for the subset of the dataset.
 
@@ -387,7 +390,9 @@ def save_to_s3_silver(
     """
 
     # Extract file information
-    file_name = main_file_dict.get("file_url")[0].split("/")[-1].rsplit(".", 1)[0]
+    file_name = (
+        main_file_dict.get("file_url")[file_url_index].split("/")[-1].rsplit(".", 1)[0]
+    )
     archive_date = pd.to_datetime(main_file_dict.get("release_date")).strftime("%B_%Y")
 
     s3_client = boto3.client("s3")

--- a/asf_mission_data_tool/getters/data_getters.py
+++ b/asf_mission_data_tool/getters/data_getters.py
@@ -4,6 +4,8 @@ import subprocess
 import toml
 import logging
 import yaml
+import io
+import pandas as pd
 from botocore.exceptions import NoCredentialsError, ClientError
 from datetime import datetime
 from typing import Callable, Any, Optional, Dict
@@ -11,6 +13,147 @@ from asf_mission_data_tool import config
 
 # Suppress information level messages from botocore
 logging.getLogger("botocore.credentials").setLevel(logging.ERROR)
+
+
+"""
+General
+"""
+
+
+def get_latest_version(dataset_name: str, filter: Optional[str] = None) -> Dict:
+    """Returns the latest version of a dataset instance from config.
+
+    Parameters
+    ----------
+    dataset_name : str
+        Name of dataset; must be a key of dataset in config/base.yaml.
+
+    filter : Optional[str], default None
+        Word to filter file URLs if only interested in gettgin the latest version of one particular category in the dataset.
+
+    Returns
+    -------
+    Dict
+        Dictionary with key-value pairs for dataset release date, file url and page url.
+    """
+    versions = config.get("dataset").get(dataset_name).get("versions")
+    if not versions:
+        raise ValueError(f"No versions found for dataset '{dataset_name}'.")
+
+    if filter:
+        filtered_versions = [
+            version
+            for version in versions
+            if any(filter in url for url in version["file_url"])
+        ]
+        if not filtered_versions:
+            raise ValueError(f"No versions found matching filter '{filter}'.")
+        latest_version = max(
+            filtered_versions,
+            key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d"),
+        )
+    else:
+        latest_version = max(
+            versions, key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d")
+        )
+    return latest_version
+
+
+def append_field_to_latest_version(
+    dataset_name: str,
+    s3_file_path: str,
+    new_field_name: str,
+    filter: Optional[str] = None,
+) -> None:
+    """Updates the base.yaml configuration file by appending a new field to the latest version entry of a specified dataset.
+    The function reads the dataset details from an existing config file, determines the latest version based on the release date and
+    updates the entry with the provided S3 file path.
+
+    Parameters
+    ----------
+    dataset_name : str
+        Name of dataset; must be a key of dataset in config/base.yaml.
+    s3_file_path : str
+        The S3 path of the silver dataset file.
+    new_field_name : str
+        The name of the new field to append to the base.yaml configuration file for the dataset of interest.
+    filter : Optional[str], optional
+        An optional filter to select specific dataset versions based on file URLs, by default None.
+    """
+
+    try:
+        # Load existing config data
+        with open("asf_mission_data_tool/config/base.yaml", "r") as file:
+            all_existing_data = yaml.safe_load(file)
+    except FileNotFoundError:
+        raise FileNotFoundError("The configuration file 'base.yaml' was not found.")
+    except yaml.YAMLError:
+        raise ValueError("Error parsing YAML file. Please check its formatting.")
+
+    # Retrieve entry for dataset
+    dataset_specific_data = all_existing_data.get("dataset", {}).get(dataset_name, {})
+    if not dataset_specific_data:
+        raise KeyError(f"Dataset '{dataset_name}' not found in config file.")
+
+    versions = dataset_specific_data.get("versions", [])
+    if not versions:
+        raise ValueError(f"No versions found for dataset '{dataset_name}'.")
+
+    # Retrieve latest version of dataset
+    if filter:
+        filtered_versions = [
+            version
+            for version in versions
+            if any(filter in url for url in version["file_url"])
+        ]
+        if not filtered_versions:
+            raise ValueError(f"No versions found matching filter '{filter}'.")
+        latest_version = max(
+            filtered_versions,
+            key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d"),
+        )
+    else:
+        latest_version = max(
+            versions, key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d")
+        )
+    latest_version[new_field_name] = s3_file_path
+
+    # Write updated data
+    with open("asf_mission_data_tool/config/base.yaml", "w") as file:
+        yaml.dump(
+            all_existing_data,
+            file,
+            default_flow_style=False,
+            sort_keys=True,
+        )
+
+    print(
+        f"{new_field_name} field added to version with release_date {latest_version['release_date']}."
+    )
+
+
+def get_from_s3(s3_key: str) -> io.BytesIO:
+    """Downloads a file from the asf-mission-data-tool S3 bucket and returns it as a BytesIO object.
+
+    Parameters
+    ----------
+    s3_file_path : str
+        The S3 key (file path) within the bucket.
+
+    Returns
+    -------
+    io.BytesIO
+        A file-like object containing the file content.
+    """
+    s3 = boto3.client("s3")
+    obj = s3.get_object(Bucket="asf-mission-data-tool", Key=s3_key)
+    content = io.BytesIO(obj["Body"].read())
+    return content
+
+
+"""
+Bronze
+"""
 
 
 def _save_provenance_to_toml(func: Callable[..., Any]) -> Callable[..., Any]:
@@ -211,105 +354,74 @@ def save_to_s3_bronze(dataset_name: str, target_url: str) -> str:
     return f"s3://asf-mission-data-tool/{main_file_path}"
 
 
-def get_latest_version(dataset_name: str, filter: Optional[str] = None) -> Dict:
-    """Returns the latest version of a dataset instance from config.
+"""
+Silver
+"""
+
+
+def save_to_s3_silver(
+    dataframe: pd.DataFrame,
+    dataset_name: str,
+    main_file_dict: Dict,
+    subset_id: str,
+) -> str:
+    """Saves a given Pandas DataFrame to the asf_mission_data_tool S3 bucket in parquet format. The file is stored in both
+    the "LATEST" directory and a date-specific archive directory.
 
     Parameters
     ----------
+    dataframe : pd.DataFrame
+    Dataframe to be saved.
     dataset_name : str
         Name of dataset; must be a key of dataset in config/base.yaml.
-
-    filter : Optional[str], default None
-        Word to filter file URLs if only interested in gettgin the latest version of one particular category in the dataset.
+    main_file_dict : Dict
+        Dictionary containing dataset metadata from config/base.yaml.
+    subset_id : str
+        An identifier for the subset of the dataset.
 
     Returns
     -------
-    Dict
-        Dictionary with key-value pairs for dataset release date, file url and page url.
-    """
-    versions = config.get("dataset").get(dataset_name).get("versions")
-    if not versions:
-        raise ValueError(f"No versions found for dataset '{dataset_name}'.")
-
-    if filter:
-        filtered_versions = [
-            version
-            for version in versions
-            if any(filter in url for url in version["file_url"])
-        ]
-        if not filtered_versions:
-            raise ValueError(f"No versions found matching filter '{filter}'.")
-        latest_version = max(
-            filtered_versions,
-            key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d"),
-        )
-    else:
-        latest_version = max(
-            versions, key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d")
-        )
-    return latest_version
-
-
-def append_file_bronze_to_latest_version(
-    dataset_name: str,
-    s3_file_path: str,
-    filter: Optional[str] = None,
-) -> None:
-    """Updates the base.yaml configuration file by appending a "file_bronze" field to the latest version entry of a specified dataset.
-    The function reads the dataset details from an existing config file, determines the latest version based on the release date and
-    updates the entry with the provided S3 file path.
-
-    Parameters
-    ----------
-    dataset_name : str
-        Name of dataset; must be a key of dataset in config/base.yaml.
-    s3_file_path : str
-        The S3 path of the bronze dataset file.
-    filter : Optional[str], optional
-        An optional filter to select specific dataset versions based on file URLs, by default None.
+    str
+        The S3 URI of the saved parquet file
     """
 
-    try:
-        # Load existing config data
-        with open("asf_mission_data_tool/config/base.yaml", "r") as file:
-            all_existing_data = yaml.safe_load(file)
-    except FileNotFoundError:
-        raise FileNotFoundError("The configuration file 'base.yaml' was not found.")
-    except yaml.YAMLError:
-        raise ValueError("Error parsing YAML file. Please check its formatting.")
+    # Extract file information
+    file_name = main_file_dict.get("file_url")[0].split("/")[-1].rsplit(".", 1)[0]
+    archive_date = pd.to_datetime(main_file_dict.get("release_date")).strftime("%B_%Y")
 
-    # Retrieve entry for dataset
-    dataset_specific_data = all_existing_data.get("dataset", {}).get(dataset_name, {})
-    if not dataset_specific_data:
-        raise KeyError(f"Dataset '{dataset_name}' not found in config file.")
+    s3_client = boto3.client("s3")
 
-    versions = dataset_specific_data.get("versions", [])
-    if not versions:
-        raise ValueError(f"No versions found for dataset '{dataset_name}'.")
-
-    # Retrieve latest version of dataset
-    if filter:
-        filtered_versions = [
-            version
-            for version in versions
-            if any(filter in url for url in version["file_url"])
-        ]
-        if not filtered_versions:
-            raise ValueError(f"No versions found matching filter '{filter}'.")
-        latest_version = max(
-            filtered_versions,
-            key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d"),
-        )
-    else:
-        latest_version = max(
-            versions, key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d")
-        )
-    latest_version["file_bronze"] = s3_file_path
-
-    # Write updated data
-    with open("asf_mission_data_tool/config/base.yaml", "w") as file:
-        yaml.dump(all_existing_data, file, default_flow_style=False, sort_keys=True)
-
-    print(
-        f"file_bronze field added to version with release_date {latest_version['release_date']}."
+    # Save to LATEST/ and archive date/
+    latest_key = f"silver/{dataset_name}/LATEST/{file_name}_{subset_id}.parquet"
+    archive_key = (
+        f"silver/{dataset_name}/{archive_date}/{file_name}_{subset_id}.parquet"
     )
+
+    with io.BytesIO() as parquet_buffer:
+
+        dataframe.to_parquet(parquet_buffer, engine="pyarrow", index=False)
+        parquet_buffer.seek(0)
+
+        try:
+            s3_client.put_object(
+                Bucket="asf-mission-data-tool",
+                Key=latest_key,
+                Body=parquet_buffer.getvalue(),
+            )
+            print(
+                f"File uploaded successfully to s3://asf-mission-data-tool/{latest_key}"
+            )
+            s3_client.put_object(
+                Bucket="asf-mission-data-tool",
+                Key=archive_key,
+                Body=parquet_buffer.getvalue(),
+            )
+            print(
+                f"File uploaded successfully to s3://asf-mission-data-tool/{archive_key}"
+            )
+        except NoCredentialsError:
+            print("Credentials not available.")
+        except Exception as e:
+            print(f"Error uploading file: {e}")
+
+    return f"s3://asf-mission-data-tool/{archive_key}"

--- a/asf_mission_data_tool/getters/data_getters.py
+++ b/asf_mission_data_tool/getters/data_getters.py
@@ -6,8 +6,10 @@ import logging
 import yaml
 import io
 import pandas as pd
+from copy import deepcopy
 from botocore.exceptions import NoCredentialsError, ClientError
 from datetime import datetime, timezone, timedelta
+from bs4 import BeautifulSoup
 from typing import Callable, Any, Optional, Dict
 from asf_mission_data_tool import config
 
@@ -18,6 +20,162 @@ logging.getLogger("botocore.credentials").setLevel(logging.ERROR)
 """
 General
 """
+
+
+def get_page_url(dataset_name: str, page_link_text: str) -> str:
+
+    # Retrieve collection page
+    collection_url = config.get("dataset").get(dataset_name).get("collection_url")
+    collection_response = requests.get(collection_url)
+
+    collection_response.raise_for_status()
+    if collection_response.status_code != 200:
+        raise ValueError(
+            f"Failed to fetch the collection page: {collection_response.status_code}"
+        )
+
+    collection_soup = BeautifulSoup(collection_response.content, "html.parser")
+
+    # Find link to most recent release page
+    page_url = None
+    for a_tag in collection_soup.find_all("a", href=True):
+        if page_link_text in a_tag.text:
+            page_url = "https://www.gov.uk" + a_tag["href"]
+            break  # first one is most recent one
+
+    if not page_url:
+        raise ValueError(f"Could not find the {page_link_text} link")
+
+    return page_url
+
+
+def get_file_url(page_url: str, file_type: str, file_text: str) -> list[str]:
+
+    # Retrieve most recent release page
+    page_response = requests.get(page_url)
+
+    page_response.raise_for_status()
+    if page_response.status_code != 200:
+        raise ValueError(f"Failed to fetch the page page: {page_response.status_code}")
+
+    page_soup = BeautifulSoup(page_response.content, "html.parser")
+
+    # Find links to files on most recent release page
+    file_url = []  # some datasets have multiple files
+    for a_tag in page_soup.find_all("a", href=True):
+        href = a_tag["href"]
+        if href.endswith(file_type) and href.startswith("http") and file_text in href:
+            file_url.append(href)
+
+    file_url = list(dict.fromkeys(file_url))  # remove duplicates
+
+    if not file_url:
+        raise ValueError(
+            f"Could not find the file link, check the link text {file_text} and file type {file_type}"
+        )
+
+    return file_url
+
+
+def get_release_date(page_url: str) -> str:
+    # Retrieve most recent release page
+    page_response = requests.get(page_url)
+
+    page_response.raise_for_status()
+    if page_response.status_code != 200:
+        raise ValueError(f"Failed to fetch the page page: {page_response.status_code}")
+
+    page_soup = BeautifulSoup(page_response.content, "html.parser")
+
+    # Extract release date
+    published_dt = page_soup.find("dt", string="Published")
+    if published_dt:
+        published_dd = published_dt.find_next("dd")
+        if published_dd:
+            published_date = published_dd.get_text(strip=True)
+
+    release_date = datetime.strptime(published_date, "%d %B %Y").strftime("%Y-%m-%d")
+
+    return release_date
+
+
+def add_new_version(
+    dataset_name: str,
+    page_url: str,
+    file_url: list[str],
+    release_date: str,
+    filter: Optional[str] = None,
+) -> None:
+
+    # Load existing config data
+    try:
+        # with open("asf_mission_data_tool/config/base.yaml", "r") as file:
+        with open(
+            "/home/eglucas/Projects/asf_mission_data_tool/asf_mission_data_tool/config/base.yaml",
+            "r",
+        ) as file:
+            all_existing_data = yaml.safe_load(file)
+    except FileNotFoundError:
+        raise FileNotFoundError("The configuration file 'base.yaml' was not found.")
+    except yaml.YAMLError:
+        raise ValueError("Error parsing YAML file. Please check its formatting.")
+
+    # Retrieve entry for dataset
+    dataset_specific_data = all_existing_data.get("dataset", {}).get(dataset_name, {})
+    if not dataset_specific_data:
+        raise KeyError(f"Dataset '{dataset_name}' not found in config file.")
+
+    versions = dataset_specific_data.get("versions", [])
+    if not versions:
+        raise ValueError(f"No versions found for dataset '{dataset_name}'.")
+
+    # Retrieve latest version of dataset to copy schema
+    if filter:
+        filtered_versions = [
+            version
+            for version in versions
+            if any(filter in url for url in version["file_url"])
+        ]
+        if not filtered_versions:
+            raise ValueError(f"No versions found matching filter '{filter}'.")
+        latest_version = max(
+            filtered_versions,
+            key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d"),
+        )
+    else:
+        latest_version = max(
+            versions, key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d")
+        )
+
+    # Create dictionary for new version to add to config
+    new_version = {
+        "page_url": page_url,
+        "file_url": file_url,
+        "release_date": release_date,
+        "tables": deepcopy(
+            latest_version["tables"]
+        ),  # assume same structure as previous release
+    }
+
+    # Add to full dataset dictionary
+    dataset_specific_data["versions"].append(new_version)
+
+    # Write updated config
+    # with open("asf_mission_data_tool/config/base.yaml", "w") as file:
+    with open(
+        "/home/eglucas/Projects/asf_mission_data_tool/asf_mission_data_tool/config/base.yaml",
+        "w",
+    ) as file:
+        yaml.dump(
+            all_existing_data,
+            file,
+            default_flow_style=False,
+            sort_keys=True,
+        )
+
+    print(
+        f"New version added to dataset {dataset_name} with release_date {release_date}."
+    )
 
 
 def get_latest_version(dataset_name: str, filter: Optional[str] = None) -> Dict:

--- a/asf_mission_data_tool/getters/data_getters.py
+++ b/asf_mission_data_tool/getters/data_getters.py
@@ -22,7 +22,9 @@ General
 """
 
 
-def get_page_url(dataset_name: str, page_link_text: str) -> str:
+def get_page_url(
+    dataset_name: str, page_link_text: str, page_link_index: Optional[int] = 0
+) -> str:
 
     # Retrieve collection page
     collection_url = config.get("dataset").get(dataset_name).get("collection_url")
@@ -37,11 +39,11 @@ def get_page_url(dataset_name: str, page_link_text: str) -> str:
     collection_soup = BeautifulSoup(collection_response.content, "html.parser")
 
     # Find link to most recent release page
-    page_url = None
+    page_urls = []
     for a_tag in collection_soup.find_all("a", href=True):
         if page_link_text in a_tag.text:
-            page_url = "https://www.gov.uk" + a_tag["href"]
-            break  # first one is most recent one
+            page_urls.append("https://www.gov.uk" + a_tag["href"])
+    page_url = page_urls[page_link_index]
 
     if not page_url:
         raise ValueError(f"Could not find the {page_link_text} link")
@@ -109,11 +111,7 @@ def add_new_version(
 
     # Load existing config data
     try:
-        # with open("asf_mission_data_tool/config/base.yaml", "r") as file:
-        with open(
-            "/home/eglucas/Projects/asf_mission_data_tool/asf_mission_data_tool/config/base.yaml",
-            "r",
-        ) as file:
+        with open("asf_mission_data_tool/config/base.yaml", "r") as file:
             all_existing_data = yaml.safe_load(file)
     except FileNotFoundError:
         raise FileNotFoundError("The configuration file 'base.yaml' was not found.")
@@ -142,9 +140,7 @@ def add_new_version(
         # Retrieve latest version of dataset to copy schema
         if filter:
             filtered_versions = [
-                version
-                for version in versions
-                if any(filter in url for url in version["file_url"])
+                version for version in versions if filter in version["page_url"]
             ]
             if not filtered_versions:
                 raise ValueError(f"No versions found matching filter '{filter}'.")
@@ -171,11 +167,7 @@ def add_new_version(
         dataset_specific_data["versions"].append(new_version)
 
         # Write updated config
-        # with open("asf_mission_data_tool/config/base.yaml", "w") as file:
-        with open(
-            "/home/eglucas/Projects/asf_mission_data_tool/asf_mission_data_tool/config/base.yaml",
-            "w",
-        ) as file:
+        with open("asf_mission_data_tool/config/base.yaml", "w") as file:
             yaml.dump(
                 all_existing_data,
                 file,

--- a/asf_mission_data_tool/getters/data_getters.py
+++ b/asf_mission_data_tool/getters/data_getters.py
@@ -129,53 +129,63 @@ def add_new_version(
     if not versions:
         raise ValueError(f"No versions found for dataset '{dataset_name}'.")
 
-    # Retrieve latest version of dataset to copy schema
-    if filter:
-        filtered_versions = [
-            version
-            for version in versions
-            if any(filter in url for url in version["file_url"])
-        ]
-        if not filtered_versions:
-            raise ValueError(f"No versions found matching filter '{filter}'.")
-        latest_version = max(
-            filtered_versions,
-            key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d"),
+    # check if fetched version already exists in config
+    version_dates = []
+    for version in versions:
+        version_dates.append(version["release_date"])
+
+    if release_date in version_dates:
+        print(
+            f"Dataset version {release_date} of {dataset_name} already exists in config."
         )
     else:
-        latest_version = max(
-            versions, key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d")
+        # Retrieve latest version of dataset to copy schema
+        if filter:
+            filtered_versions = [
+                version
+                for version in versions
+                if any(filter in url for url in version["file_url"])
+            ]
+            if not filtered_versions:
+                raise ValueError(f"No versions found matching filter '{filter}'.")
+            latest_version = max(
+                filtered_versions,
+                key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d"),
+            )
+        else:
+            latest_version = max(
+                versions, key=lambda x: datetime.strptime(x["release_date"], "%Y-%m-%d")
+            )
+
+        # Create dictionary for new version to add to config
+        new_version = {
+            "page_url": page_url,
+            "file_url": file_url,
+            "release_date": release_date,
+            "tables": deepcopy(
+                latest_version["tables"]
+            ),  # assume same structure as previous release
+        }
+
+        # Add to full dataset dictionary
+        dataset_specific_data["versions"].append(new_version)
+
+        # Write updated config
+        # with open("asf_mission_data_tool/config/base.yaml", "w") as file:
+        with open(
+            "/home/eglucas/Projects/asf_mission_data_tool/asf_mission_data_tool/config/base.yaml",
+            "w",
+        ) as file:
+            yaml.dump(
+                all_existing_data,
+                file,
+                default_flow_style=False,
+                sort_keys=True,
+            )
+
+        print(
+            f"New version added to dataset {dataset_name} with release_date {release_date}."
         )
-
-    # Create dictionary for new version to add to config
-    new_version = {
-        "page_url": page_url,
-        "file_url": file_url,
-        "release_date": release_date,
-        "tables": deepcopy(
-            latest_version["tables"]
-        ),  # assume same structure as previous release
-    }
-
-    # Add to full dataset dictionary
-    dataset_specific_data["versions"].append(new_version)
-
-    # Write updated config
-    # with open("asf_mission_data_tool/config/base.yaml", "w") as file:
-    with open(
-        "/home/eglucas/Projects/asf_mission_data_tool/asf_mission_data_tool/config/base.yaml",
-        "w",
-    ) as file:
-        yaml.dump(
-            all_existing_data,
-            file,
-            default_flow_style=False,
-            sort_keys=True,
-        )
-
-    print(
-        f"New version added to dataset {dataset_name} with release_date {release_date}."
-    )
 
 
 def get_latest_version(dataset_name: str, filter: Optional[str] = None) -> Dict:

--- a/asf_mission_data_tool/notebooks/checking_silver.py
+++ b/asf_mission_data_tool/notebooks/checking_silver.py
@@ -1,0 +1,61 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     comment_magics: true
+#     custom_cell_magics: kql
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.2
+#   kernelspec:
+#     display_name: asf_mission_data_tool
+#     language: python
+#     name: python3
+# ---
+
+# %%
+import pandas as pd
+from asf_mission_data_tool.getters.data_getters import get_from_s3
+
+# %%
+# Heat Pump Deployment
+# silver_key = "silver/heat_pump_deployment_quarterly_statistics/LATEST/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2024_Q3_Table_1_2.parquet"
+silver_key = "silver/heat_pump_deployment_quarterly_statistics/March_2025/Heat_pump_deployment_quarterly_statistics_United_Kingdom_2024_Q4_Table_1_3.parquet"
+
+# %%
+# UK territorial ghg emissions
+silver_key = "silver/uk_territorial_greenhouse_gas_emissions_statistics/LATEST/final-greenhouse-gas-emissions-tables-2022_1_2.parquet"
+# silver_key = "silver/uk_territorial_greenhouse_gas_emissions_statistics/LATEST/final-greenhouse-gas-emissions-tables-2022_7_1.parquet"
+
+# %%
+# Energy price cap
+silver_key = "silver/energy_price_cap_levels/February_2025/Annex-9-Levelisation-allowance-methodology-and-levelised-cap-levels-v1.5_1c_Consumption_adjusted_levels.parquet"
+
+# %%
+# CB7
+# silver_key = "silver/seventh_carbon_budget/LATEST/The-Seventh-Carbon-Budget-full-dataset_Economy_wide_data.parquet"
+# silver_key = "silver/seventh_carbon_budget/LATEST/The-Seventh-Carbon-Budget-full-dataset_3_5.parquet"
+# silver_key = "silver/seventh_carbon_budget/LATEST/The-Seventh-Carbon-Budget-full-dataset_7_2_1.parquet"
+silver_key = "silver/seventh_carbon_budget/LATEST/The-Seventh-Carbon-Budget-full-dataset_7_2_4.parquet"
+
+# %%
+# EPCs
+silver_key = "silver/energy_performance_of_buildings_certificates/LATEST/A1-_All_Properties_D1_England_Only.parquet"
+
+# %%
+# Check metadata was properly encoded
+restored_dataframe = pd.read_parquet(get_from_s3(silver_key))
+restored_dataframe
+
+# %%
+restored_dataframe.dtypes
+
+# %%
+restored_dataframe.attrs
+
+# %%
+restored_dataframe.isnull().sum()
+
+# %%

--- a/asf_mission_data_tool/pipeline/energy_consumption_in_the_uk_pipeline/bronze_to_silver_energy_consumption_in_the_uk.py
+++ b/asf_mission_data_tool/pipeline/energy_consumption_in_the_uk_pipeline/bronze_to_silver_energy_consumption_in_the_uk.py
@@ -1,0 +1,246 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     comment_magics: true
+#     custom_cell_magics: kql
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.2
+#   kernelspec:
+#     display_name: asf_mission_data_tool
+#     language: python
+#     name: python3
+# ---
+
+# %%
+import pandas as pd
+
+# %%
+from asf_mission_data_tool.getters.data_getters import (
+    get_from_s3,
+    save_to_s3_silver,
+    append_field_to_latest_version,
+    get_latest_version,
+)
+
+# %%
+from asf_mission_data_tool.getters.bronze_to_silver_transformations import (
+    set_logger,
+    add_year_column,
+    rename_columns,
+    drop_row,
+    melt_dataframe,
+    assert_dtypes,
+    replace_value_in_column,
+    remove_line_break_chars,
+)
+
+# %%
+# Dataset specific variables
+dataset_name = "energy_consumption_in_the_uk"
+latest_version = get_latest_version(dataset_name)
+log_file_path = dataset_name + ".log"
+
+# %%
+# Set up logger for transformation tracking
+set_logger(log_file_path)
+
+# %%
+# Check table-level information is available
+tables = latest_version.get("tables")
+if not tables:
+    raise ValueError("No 'tables' key found in config, or 'tables' is empty.")
+
+# %%
+# Download file content from s3
+content = {}
+for file_url in latest_version.get("file_url"):
+    file_name = file_url.split("/")[-1]
+    bronze_key = [
+        file_bronze
+        for file_bronze in latest_version.get("file_bronze")
+        if file_name in file_bronze
+    ][0].replace("s3://asf-mission-data-tool/", "")
+    content[file_url] = get_from_s3(s3_key=bronze_key)
+
+# %%
+# Read and series transformations for each table in dataset
+transformed_tables = {}
+for table_dict in latest_version.get("tables"):
+
+    # Extract information
+    sheet_name = table_dict.get("sheet_name")
+    if not sheet_name:
+        raise ValueError("Missing 'sheet_name' in table data.")
+
+    skiprows = table_dict.get("skiprows")
+    if not skiprows:
+        raise ValueError("Missing 'skiprows' in table data.")
+
+    dtypes = table_dict.get("dtypes")
+
+    file_url = table_dict.get("file_url")
+
+    # Raise error if more tables are added
+    if sheet_name not in ["Table C1", "Table C9"]:
+        raise ValueError(
+            "New tables have been added that are not currently accounted for in pipeline."
+        )
+
+    table_df = pd.read_excel(
+        content[file_url], sheet_name=sheet_name, skiprows=skiprows, header=[0, 1]
+    )
+
+    if sheet_name == "Table C1":
+        table_df = (
+            (
+                add_year_column(
+                    dataframe=table_df,
+                    table_name=sheet_name,
+                    year_column_name=("Year", "Year"),
+                    existing_year_column_to_duplicate=("Industry [Note 1]", "Year"),
+                )
+                .pipe(
+                    melt_dataframe,
+                    table_name=sheet_name,
+                    id_vars=[("Year", "Year")],
+                    value_vars=table_df.columns.tolist(),
+                    value_name="energy_consumption_ktoe",
+                )
+                .pipe(
+                    rename_columns,
+                    table_name=sheet_name,
+                    column_map={
+                        ("Year", "Year"): "year",
+                        "variable_0": "sector",
+                        "variable_1": "category",
+                    },
+                )
+            )
+            .pipe(
+                remove_line_break_chars, table_name=sheet_name, column_to_clean="sector"
+            )
+            .pipe(
+                remove_line_break_chars,
+                table_name=sheet_name,
+                column_to_clean="category",
+            )
+        )
+
+        redundant_year_rows_in_sector_col = table_df.loc[
+            table_df["sector"].str.contains("Year", na=False)
+        ].index.tolist()
+
+        table_df = drop_row(
+            dataframe=table_df,
+            table_name=sheet_name,
+            index_list_to_drop=redundant_year_rows_in_sector_col,
+        )
+
+        redundant_year_rows_in_category_col = table_df.loc[
+            table_df["category"].str.contains("Year", na=False)
+        ].index.tolist()
+        table_df = drop_row(
+            dataframe=table_df,
+            table_name=sheet_name,
+            index_list_to_drop=redundant_year_rows_in_category_col,
+        )
+
+        table_df = replace_value_in_column(
+            dataframe=table_df,
+            table_name=sheet_name,
+            column_name="energy_consumption_ktoe",
+            replaced_value="[x]",
+            replacement_value=None,
+        )
+
+    if sheet_name == "Table C9":
+        table_df = (
+            add_year_column(
+                dataframe=table_df,
+                table_name=sheet_name,
+                year_column_name=("Year", "Year"),
+                existing_year_column_to_duplicate=("Electricity", "Year"),
+            )
+            .pipe(
+                melt_dataframe,
+                table_name=sheet_name,
+                id_vars=[("Year", "Year")],
+                value_vars=table_df.columns.tolist(),
+                value_name="value",
+            )
+            .pipe(
+                rename_columns,
+                table_name=sheet_name,
+                column_map={
+                    ("Year", "Year"): "year",
+                    "variable_0": "fuel",
+                    "variable_1": "variable",
+                },
+            )
+        ).pipe(
+            remove_line_break_chars, table_name=sheet_name, column_to_clean="variable"
+        )
+
+        redundant_year_rows_in_fuel_col = table_df.loc[
+            table_df["fuel"].str.contains("Year", na=False)
+        ].index.tolist()
+        table_df = drop_row(
+            dataframe=table_df,
+            table_name=sheet_name,
+            index_list_to_drop=redundant_year_rows_in_fuel_col,
+        )
+
+        redundant_year_rows_in_variable_col = table_df.loc[
+            table_df["variable"].str.contains("Year", na=False)
+        ].index.tolist()
+        table_df = drop_row(
+            dataframe=table_df,
+            table_name=sheet_name,
+            index_list_to_drop=redundant_year_rows_in_variable_col,
+        )
+
+    table_df = assert_dtypes(
+        dataframe=table_df, table_name=sheet_name, expected_dtypes=dtypes
+    )
+
+    transformed_tables[sheet_name] = table_df
+
+# %%
+# Load to s3 with transformation log as metadata
+s3_file_path = []
+for name, dataframe in transformed_tables.items():
+
+    metadata = {}
+    with open(log_file_path, "r") as log_file:
+        i = 1
+        for line in log_file:
+            if name in line:
+                metadata[f"bronze_to_silver_transformation_{i}"] = line
+                i = i + 1
+
+    # Encode metadata to parquet metadata via DataFrame attrs property
+    dataframe.attrs = metadata
+
+    file_path = save_to_s3_silver(
+        dataframe=dataframe,
+        dataset_name=dataset_name,
+        main_file_dict=latest_version,
+        file_url_index=0,
+        subset_id=name.replace(" ", "_"),
+    )
+    s3_file_path.append(file_path)
+
+# %%
+# Append "file_silver" to config
+if not s3_file_path:
+    pass
+else:
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_silver",
+    )

--- a/asf_mission_data_tool/pipeline/energy_consumption_in_the_uk_pipeline/get_energy_consumption_in_the_uk_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/energy_consumption_in_the_uk_pipeline/get_energy_consumption_in_the_uk_to_bronze.py
@@ -1,0 +1,22 @@
+from asf_mission_data_tool.getters.data_getters import (
+    save_to_s3_bronze,
+    get_latest_version,
+    append_file_bronze_to_latest_version,
+)
+
+dataset_name = "energy_consumption_in_the_uk"
+
+latest_version = get_latest_version(dataset_name)
+
+s3_file_path = []
+for file_url in latest_version.get("file_url"):
+    file_path = save_to_s3_bronze(dataset_name=dataset_name, target_url=file_url)
+    if file_path:
+        s3_file_path.append(file_path)
+
+if not s3_file_path:
+    pass
+else:
+    append_file_bronze_to_latest_version(
+        dataset_name=dataset_name, s3_file_path=s3_file_path
+    )

--- a/asf_mission_data_tool/pipeline/energy_consumption_in_the_uk_pipeline/get_energy_consumption_in_the_uk_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/energy_consumption_in_the_uk_pipeline/get_energy_consumption_in_the_uk_to_bronze.py
@@ -1,7 +1,7 @@
 from asf_mission_data_tool.getters.data_getters import (
     save_to_s3_bronze,
     get_latest_version,
-    append_file_bronze_to_latest_version,
+    append_field_to_latest_version,
 )
 
 dataset_name = "energy_consumption_in_the_uk"
@@ -17,6 +17,8 @@ for file_url in latest_version.get("file_url"):
 if not s3_file_path:
     pass
 else:
-    append_file_bronze_to_latest_version(
-        dataset_name=dataset_name, s3_file_path=s3_file_path
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_bronze",
     )

--- a/asf_mission_data_tool/pipeline/energy_performance_of_buildings_certificates_pipeline/bronze_to_silver_energy_performance_of_buildings_certificates.py
+++ b/asf_mission_data_tool/pipeline/energy_performance_of_buildings_certificates_pipeline/bronze_to_silver_energy_performance_of_buildings_certificates.py
@@ -1,0 +1,194 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     comment_magics: true
+#     custom_cell_magics: kql
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.2
+#   kernelspec:
+#     display_name: asf_mission_data_tool
+#     language: python
+#     name: python3
+# ---
+
+# %%
+import pandas as pd
+
+# %%
+from asf_mission_data_tool.getters.data_getters import (
+    get_from_s3,
+    save_to_s3_silver,
+    append_field_to_latest_version,
+    get_latest_version,
+)
+
+# %%
+from asf_mission_data_tool.getters.bronze_to_silver_transformations import (
+    set_logger,
+    rename_columns,
+    drop_row,
+    extract_substring_in_column,
+    melt_dataframe,
+    assert_dtypes,
+)
+
+# %%
+# Dataset specific variables
+dataset_name = "energy_performance_of_buildings_certificates"
+latest_version = get_latest_version(dataset_name)
+log_file_path = dataset_name + ".log"
+
+# %%
+# Set up logger for transformation tracking
+set_logger(log_file_path)
+
+# %%
+# Check table-level information is available
+tables = latest_version.get("tables")
+if not tables:
+    raise ValueError("No 'tables' key found in config, or 'tables' is empty.")
+
+# %%
+# Download file content from s3
+content = {}
+for file_url in latest_version.get("file_url"):
+    file_name = file_url.split("/")[-1]
+    bronze_key = [
+        file_bronze
+        for file_bronze in latest_version.get("file_bronze")
+        if file_name in file_bronze
+    ][0].replace("s3://asf-mission-data-tool/", "")
+    content[file_url] = get_from_s3(s3_key=bronze_key)
+
+# %%
+# Read and series transformations for each table in dataset
+transformed_tables = {}
+for table_dict in latest_version.get("tables"):
+
+    # Extract information
+    sheet_name = table_dict.get("sheet_name")
+    if not sheet_name:
+        raise ValueError("Missing 'sheet_name' in table data.")
+
+    skiprows = table_dict.get("skiprows")
+    if not skiprows:
+        raise ValueError("Missing 'skiprows' in table data.")
+
+    dtypes = table_dict.get("dtypes")
+
+    file_url = table_dict.get("file_url")
+
+    # Raise error if more tables are added
+    if sheet_name not in [
+        "D1_England_Only",
+        "D1_Wales_Only",
+        "D2_England_Only",
+        "D2_Wales_Only",
+        "D3_England_Only",
+        "D3_Wales_Only",
+    ]:
+        raise ValueError(
+            "New tables have been added that are not currently accounted for in pipeline."
+        )
+
+    if "D1" in sheet_name:  # Energy Efficiency Rating
+        column_map = {
+            "A": "Energy Effiency Rating A",
+            "B": "Energy Effiency Rating B",
+            "C": "Energy Effiency Rating C",
+            "D": "Energy Effiency Rating D",
+            "E": "Energy Effiency Rating E",
+            "F": "Energy Effiency Rating F",
+            "G": "Energy Effiency Rating G",
+            "Not Recorded": "Energy Effiency Rating Not Recorded",
+        }
+
+    elif "D2" in sheet_name:  # Environmental Impact Rating
+        column_map = {
+            "A": "Environmental Impact Rating A",
+            "B": "Environmental Impact Rating B",
+            "C": "Environmental Impact Rating C",
+            "D": "Environmental Impact Rating D",
+            "E": "Environmental Impact Rating E",
+            "F": "Environmental Impact Rating F",
+            "G": "Environmental Impact RatingR G",
+            "Not Recorded": "Environmental Impact Rating Not Recorded",
+        }
+    else:
+        column_map = {}
+
+    table_df = pd.read_excel(
+        content[file_url], sheet_name=sheet_name, skiprows=skiprows
+    ).pipe(rename_columns, table_name=sheet_name, column_map=column_map)
+
+    nan_quarter_indices = table_df.loc[pd.isna(table_df["Quarter"]), :].index.tolist()
+
+    table_df = (
+        table_df.pipe(
+            drop_row,
+            table_name=sheet_name,
+            index_list_to_drop=nan_quarter_indices,
+        )
+        .pipe(
+            extract_substring_in_column,
+            table_name=sheet_name,
+            separator="/",
+            column_name="Quarter",
+            segment_to_extract=1,
+        )
+        .pipe(
+            melt_dataframe,
+            table_name=sheet_name,
+            id_vars=["Year", "Quarter"],
+            var_name="Variable",
+            value_name="Value",
+        )
+        .pipe(assert_dtypes, table_name=sheet_name, expected_dtypes=dtypes)
+    )
+
+    transformed_tables[sheet_name] = table_df
+
+# %%
+# Load to s3 with transformation log as metadata
+s3_file_path = []
+for name, dataframe in transformed_tables.items():
+
+    metadata = {}
+    with open(log_file_path, "r") as log_file:
+        i = 1
+        for line in log_file:
+            if name in line:
+                metadata[f"bronze_to_silver_transformation_{i}"] = line
+                i = i + 1
+
+    # Encode metadata to parquet metadata via DataFrame attrs property
+    dataframe.attrs = metadata
+
+    # Get corresponding file url of table
+    for dict in latest_version.get("tables"):
+        if dict["sheet_name"] == name:
+            file_url = dict["file_url"]
+
+    file_path = save_to_s3_silver(
+        dataframe=dataframe,
+        dataset_name=dataset_name,
+        main_file_dict=latest_version,
+        file_url_index=latest_version["file_url"].index(file_url),
+        subset_id=name.replace(" ", "_"),
+    )
+    s3_file_path.append(file_path)
+
+# %%
+# Append "file_silver" to config
+if not s3_file_path:
+    pass
+else:
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_silver",
+    )

--- a/asf_mission_data_tool/pipeline/energy_performance_of_buildings_certificates_pipeline/get_energy_performance_of_buildings_certificates_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/energy_performance_of_buildings_certificates_pipeline/get_energy_performance_of_buildings_certificates_to_bronze.py
@@ -1,0 +1,22 @@
+from asf_mission_data_tool.getters.data_getters import (
+    save_to_s3_bronze,
+    get_latest_version,
+    append_file_bronze_to_latest_version,
+)
+
+dataset_name = "energy_performance_of_buildings_certificates"
+
+latest_version = get_latest_version(dataset_name)
+
+s3_file_path = []
+for file_url in latest_version.get("file_url"):
+    file_path = save_to_s3_bronze(dataset_name=dataset_name, target_url=file_url)
+    if file_path:
+        s3_file_path.append(file_path)
+
+if not s3_file_path:
+    pass
+else:
+    append_file_bronze_to_latest_version(
+        dataset_name=dataset_name, s3_file_path=s3_file_path
+    )

--- a/asf_mission_data_tool/pipeline/energy_performance_of_buildings_certificates_pipeline/get_energy_performance_of_buildings_certificates_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/energy_performance_of_buildings_certificates_pipeline/get_energy_performance_of_buildings_certificates_to_bronze.py
@@ -1,7 +1,7 @@
 from asf_mission_data_tool.getters.data_getters import (
     save_to_s3_bronze,
     get_latest_version,
-    append_file_bronze_to_latest_version,
+    append_field_to_latest_version,
 )
 
 dataset_name = "energy_performance_of_buildings_certificates"
@@ -17,6 +17,8 @@ for file_url in latest_version.get("file_url"):
 if not s3_file_path:
     pass
 else:
-    append_file_bronze_to_latest_version(
-        dataset_name=dataset_name, s3_file_path=s3_file_path
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_bronze",
     )

--- a/asf_mission_data_tool/pipeline/energy_price_cap_levels_pipeline/bronze_to_silver_energy_price_cap_levels.py
+++ b/asf_mission_data_tool/pipeline/energy_price_cap_levels_pipeline/bronze_to_silver_energy_price_cap_levels.py
@@ -1,0 +1,129 @@
+import pandas as pd
+
+from asf_mission_data_tool.getters.data_getters import (
+    get_from_s3,
+    save_to_s3_silver,
+    append_field_to_latest_version,
+    get_latest_version,
+)
+
+from asf_mission_data_tool.getters.bronze_to_silver_transformations import (
+    set_logger,
+    convert_tariff_tables_to_tidy,
+    convert_to_nan,
+    assert_dtypes,
+    expand_price_cap_period,
+    rename_columns,
+)
+
+
+# Dataset specific variables
+dataset_name = "energy_price_cap_levels"
+latest_version = get_latest_version(dataset_name)
+log_file_path = dataset_name + ".log"
+
+# Set up logger for transformation tracking
+set_logger(log_file_path)
+
+
+# Check table-level information is available
+tables = latest_version.get("tables")
+if not tables:
+    raise ValueError("No 'tables' key found in config, or 'tables' is empty.")
+
+# Download file content from s3
+latest_version_bronze_key = (
+    get_latest_version(dataset_name)
+    .get("file_bronze")[0]
+    .replace("s3://asf-mission-data-tool/", "")
+)
+content = get_from_s3(s3_key=latest_version_bronze_key)
+
+
+# Read and series transformations for each table in dataset
+transformed_tables = {}
+for table_dict in latest_version.get("tables"):
+
+    # Extract information
+    sheet_name = table_dict.get("sheet_name")
+    if not sheet_name:
+        raise ValueError("Missing 'sheet_name' in table data.")
+
+    # Raise error if more tables are added
+    if sheet_name not in ["1c Consumption adjusted levels"]:
+        raise ValueError(
+            "New tables have been added that are not currently accounted for in pipeline."
+        )
+
+    column_map = {
+        "Payment method": "payment_method",
+        "Fuel": "fuel",
+        "Consumption": "consumption",
+        "Tariff component": "tariff_component",
+        "Price cap period": "price_cap_period",
+        "Price cap period start": "price_cap_period_start",
+        "Price cap period end": "price_cap_period_end",
+        "value": "value",
+    }
+
+    table_df = (
+        (
+            pd.read_excel(content, sheet_name=sheet_name)
+            .pipe(convert_tariff_tables_to_tidy, table_name=sheet_name)
+            .pipe(
+                convert_to_nan,
+                column_name="value",
+                to_replace="-",
+                table_name=sheet_name,
+            )
+        )
+        .pipe(
+            expand_price_cap_period,
+            column_name="Price cap period",
+            table_name=sheet_name,
+        )
+        .pipe(rename_columns, table_name=sheet_name, column_map=column_map)
+        .pipe(
+            assert_dtypes,
+            table_name=sheet_name,
+            expected_dtypes=table_dict.get("dtypes"),
+        )
+    )
+
+    transformed_tables[sheet_name] = table_df
+
+
+# Load to s3 with transformation log as metadata
+s3_file_path = []
+for name, dataframe in transformed_tables.items():
+
+    metadata = {}
+    with open(log_file_path, "r") as log_file:
+        i = 1
+        for line in log_file:
+            if name in line:
+                metadata[f"bronze_to_silver_transformation_{i}"] = line
+                i = i + 1
+
+    # Encode metadata to parquet metadata via DataFrame attrs property
+    dataframe.attrs = metadata
+
+    file_path = save_to_s3_silver(
+        dataframe=dataframe,
+        dataset_name=dataset_name,
+        main_file_dict=latest_version,
+        file_url_index=0,
+        subset_id=name.replace(" ", "_"),
+    )
+    s3_file_path.append(file_path)
+
+
+# Append "file_silver" to config
+if not s3_file_path:
+    pass
+else:
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_silver",
+    )

--- a/asf_mission_data_tool/pipeline/energy_price_cap_levels_pipeline/get_energy_price_cap_levels_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/energy_price_cap_levels_pipeline/get_energy_price_cap_levels_to_bronze.py
@@ -1,0 +1,22 @@
+from asf_mission_data_tool.getters.data_getters import (
+    save_to_s3_bronze,
+    get_latest_version,
+    append_file_bronze_to_latest_version,
+)
+
+dataset_name = "energy_price_cap_levels"
+
+latest_version = get_latest_version(dataset_name)
+
+s3_file_path = []
+for file_url in latest_version.get("file_url"):
+    file_path = save_to_s3_bronze(dataset_name=dataset_name, target_url=file_url)
+    if file_path:
+        s3_file_path.append(file_path)
+
+if not s3_file_path:
+    pass
+else:
+    append_file_bronze_to_latest_version(
+        dataset_name=dataset_name, s3_file_path=s3_file_path
+    )

--- a/asf_mission_data_tool/pipeline/energy_price_cap_levels_pipeline/get_energy_price_cap_levels_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/energy_price_cap_levels_pipeline/get_energy_price_cap_levels_to_bronze.py
@@ -1,7 +1,7 @@
 from asf_mission_data_tool.getters.data_getters import (
     save_to_s3_bronze,
     get_latest_version,
-    append_file_bronze_to_latest_version,
+    append_field_to_latest_version,
 )
 
 dataset_name = "energy_price_cap_levels"
@@ -17,6 +17,8 @@ for file_url in latest_version.get("file_url"):
 if not s3_file_path:
     pass
 else:
-    append_file_bronze_to_latest_version(
-        dataset_name=dataset_name, s3_file_path=s3_file_path
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_bronze",
     )

--- a/asf_mission_data_tool/pipeline/english_housing_survey_pipeline/bronze_to_silver_english_housing_survey.py
+++ b/asf_mission_data_tool/pipeline/english_housing_survey_pipeline/bronze_to_silver_english_housing_survey.py
@@ -1,0 +1,432 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     comment_magics: true
+#     custom_cell_magics: kql
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.2
+#   kernelspec:
+#     display_name: asf_mission_data_tool
+#     language: python
+#     name: python3
+# ---
+
+# %%
+import pandas as pd
+
+# %%
+from asf_mission_data_tool.getters.data_getters import (
+    get_from_s3,
+    save_to_s3_silver,
+    append_field_to_latest_version,
+    get_latest_version,
+)
+
+# %%
+from asf_mission_data_tool.getters.bronze_to_silver_transformations import (
+    set_logger,
+    melt_dataframe,
+    drop_nan_rows,
+    drop_nan_columns,
+    drop_duplicate_rows,
+    rename_columns,
+    drop_row,
+    assert_dtypes,
+    remove_special_chars,
+    trim_whitespace,
+    replace_value_in_column,
+)
+
+# %%
+# Dataset specific variables
+dataset_name = "english_housing_survey"
+latest_version = get_latest_version(dataset_name)
+log_file_path = dataset_name + ".log"
+
+# %%
+# Set up logger for transformation tracking
+set_logger(log_file_path)
+
+# %%
+# Check table-level information is available
+tables = latest_version.get("tables")
+if not tables:
+    raise ValueError("No 'tables' key found in config, or 'tables' is empty.")
+
+# %%
+# Download file content from s3
+content = {}
+for file_url in latest_version.get("file_url"):
+    file_name = file_url.split("/")[-1]
+    bronze_key = [
+        file_bronze
+        for file_bronze in latest_version.get("file_bronze")
+        if file_name in file_bronze
+    ][0].replace("s3://asf-mission-data-tool/", "")
+    content[file_url] = get_from_s3(s3_key=bronze_key)
+
+# %%
+# Read and series transformations for each table in dataset
+transformed_tables = {}
+for table_dict in latest_version.get("tables"):
+
+    # Extract information
+    sheet_name = table_dict.get("sheet_name")
+    if not sheet_name:
+        raise ValueError("Missing 'sheet_name' in table data.")
+
+    skiprows = table_dict.get("skiprows")
+    if not skiprows:
+        raise ValueError("Missing 'skiprows' in table data.")
+
+    dtypes = table_dict.get("dtypes")
+
+    file_url = table_dict.get("file_url")
+
+    # Raise error if more tables are added
+    if sheet_name not in ["AT2_5", "AT2_6", "AT2_7", "AT2_8"]:
+        raise ValueError(
+            "New tables have been added that are not currently accounted for in pipeline."
+        )
+
+    # Main heating system over time
+    if sheet_name in ["AT2_5"]:
+        table_df = (
+            pd.read_excel(content[file_url], sheet_name=sheet_name, skiprows=skiprows)
+            .pipe(drop_nan_rows, table_name=sheet_name, threshold=2)
+            .pipe(drop_nan_columns, table_name=sheet_name)
+            .pipe(
+                rename_columns,
+                table_name=sheet_name,
+                column_map={"Unnamed: 1": "main_heating_system"},
+            )
+            .pipe(trim_whitespace, table_name=sheet_name)
+            .reset_index(drop=True)
+        )
+
+        # Add units column
+        unit_map = {
+            "central heating": "thousands of dwellings",
+            "storage heater": "thousands of dwellings",
+            "fixed room/portable heater": "thousands of dwellings",
+            "total": "thousands of dwellings",
+            "sample size": "dwellings",
+        }
+        percent_rows = [
+            "central heating",
+            "storage heater",
+            "fixed room/portable heater",
+            "total",
+        ]
+        percentage_start_index = (
+            table_df[table_df["main_heating_system"] == "total"].index[0] + 1
+        )
+        for idx in table_df.index:
+            if (
+                idx >= percentage_start_index
+                and table_df.loc[idx, "main_heating_system"] in percent_rows
+            ):
+                unit = "percentages"
+            else:
+                unit = unit_map.get(table_df.loc[idx, "main_heating_system"])
+            table_df.loc[idx, "unit"] = unit
+
+        table_df = melt_dataframe(
+            dataframe=table_df,
+            table_name=sheet_name,
+            id_vars=["main_heating_system", "unit"],
+            value_name="value",
+            var_name="year",
+        ).pipe(
+            assert_dtypes,
+            table_name=sheet_name,
+            expected_dtypes=table_dict.get("dtypes"),
+        )
+
+    # Main heating system by tenure in latest year
+    if sheet_name in ["AT2_6"]:
+        table_df = (
+            pd.read_excel(content[file_url], sheet_name=sheet_name, skiprows=skiprows)
+            .pipe(drop_nan_rows, table_name=sheet_name, threshold=2)
+            .pipe(drop_nan_columns, table_name=sheet_name)
+            .pipe(
+                rename_columns,
+                table_name=sheet_name,
+                column_map={"Unnamed: 1": "tenure"},
+            )
+            .pipe(trim_whitespace, table_name=sheet_name)
+            .reset_index(drop=True)
+        )
+        # Rearrange sample size column to ensure different unit
+        table_df_cut = table_df.dropna(axis="rows", thresh=5)
+        table_df = table_df.drop("sample size", axis=1)
+        table_df = pd.concat(
+            [table_df, table_df_cut[["tenure", "sample size"]]]
+        ).reset_index(drop=True)
+
+        # Add units column
+        tenure_labels = [
+            "owner occupied",
+            "private rented",
+            "all private sector",
+            "local authority",
+            "housing association",
+            "all social sector",
+            "all tenures",
+        ]
+        percentage_start_index = (
+            table_df[table_df["tenure"] == "all tenures"].index[0] + 1
+        )
+        sample_size_start_index = (
+            table_df[table_df["tenure"] == "all tenures"].index[1] + 1
+        )
+        for idx in table_df.index:
+            if idx >= percentage_start_index and idx < sample_size_start_index:
+                unit = "percentages"
+            elif idx >= sample_size_start_index:
+                unit = "dwellings"
+            else:
+                unit = "thousands of dwellings"
+            table_df.loc[idx, "unit"] = unit
+
+        table_df = rename_columns(
+            dataframe=table_df,
+            table_name=sheet_name,
+            column_map={
+                "centralheating": "central heating",
+                "storageheater": "storage heater",
+            },
+        ).pipe(
+            melt_dataframe,
+            table_name=sheet_name,
+            id_vars=["tenure", "unit"],
+            value_name="value",
+            var_name="variable",
+        )
+
+        # Drop redundant rows
+        table_df = drop_duplicate_rows(
+            dataframe=table_df,
+            table_name=sheet_name,
+            consider_columns=["tenure", "variable", "value"],
+            keep=False,
+        ).pipe(
+            drop_duplicate_rows,
+            table_name=sheet_name,
+            consider_columns=["tenure", "unit", "value"],
+            keep=False,
+        )
+
+        table_df = assert_dtypes(
+            dataframe=table_df,
+            table_name=sheet_name,
+            expected_dtypes=table_dict.get("dtypes"),
+        )
+
+    # Boiler types over time
+    if sheet_name in ["AT2_7"]:
+        table_df = (
+            pd.read_excel(content[file_url], sheet_name=sheet_name, skiprows=skiprows)
+            .pipe(drop_nan_rows, table_name=sheet_name, threshold=2)
+            .pipe(drop_nan_columns, table_name=sheet_name)
+            .pipe(
+                rename_columns,
+                table_name=sheet_name,
+                column_map={"Unnamed: 1": "boiler_type"},
+            )
+            .pipe(trim_whitespace, table_name=sheet_name)
+            .reset_index(drop=True)
+        )
+
+        # Add units column
+        unit_map = {
+            "standard boiler": "thousands of dwellings",
+            "back boiler": "thousands of dwellings",
+            "combination boiler": "thousands of dwellings",
+            "condensing boiler": "thousands of dwellings",
+            "condensing-combination boiler": "thousands of dwellings",
+            "no boiler": "thousands of dwellings",
+            "total": "thousands of dwellings",
+            "sample size": "dwellings",
+        }
+        percent_rows = [
+            "standard boiler",
+            "back boiler",
+            "combination boiler",
+            "condensing boiler",
+            "condensing-combination boiler",
+            "no boiler" "total",
+        ]
+        percentage_start_index = (
+            table_df[table_df["boiler_type"] == "total"].index[0] + 1
+        )
+        for idx in table_df.index:
+            if (
+                idx >= percentage_start_index
+                and table_df.loc[idx, "boiler_type"] in percent_rows
+            ):
+                unit = "percentages"
+            else:
+                unit = unit_map.get(table_df.loc[idx, "boiler_type"])
+            table_df.loc[idx, "unit"] = unit
+
+        table_df = (
+            melt_dataframe(
+                dataframe=table_df,
+                table_name=sheet_name,
+                id_vars=["boiler_type", "unit"],
+                value_name="value",
+                var_name="year",
+            )
+            .pipe(
+                replace_value_in_column,
+                table_name=sheet_name,
+                column_name="value",
+                replaced_value="-",
+                replacement_value=None,
+            )
+            .pipe(
+                assert_dtypes,
+                table_name=sheet_name,
+                expected_dtypes=table_dict.get("dtypes"),
+            )
+        )
+
+    # Boiler type by tenure in latest year
+    if sheet_name in ["AT2_8"]:
+        table_df = (
+            pd.read_excel(content[file_url], sheet_name=sheet_name, skiprows=skiprows)
+            .pipe(drop_nan_rows, table_name=sheet_name, threshold=2)
+            .pipe(drop_nan_columns, table_name=sheet_name)
+            .pipe(
+                rename_columns,
+                table_name=sheet_name,
+                column_map={"Unnamed: 1": "tenure"},
+            )
+            .pipe(trim_whitespace, table_name=sheet_name)
+            .reset_index(drop=True)
+        )
+
+        # Rearrange sample size column to ensure different unit
+        table_df_cut = table_df[table_df["samplesize"] != 100.0]
+        table_df = table_df.drop("samplesize", axis=1)
+        table_df = pd.concat(
+            [table_df, table_df_cut[["tenure", "samplesize"]]]
+        ).reset_index(drop=True)
+
+        # Add units column
+        tenure_labels = [
+            "owner occupied",
+            "private rented",
+            "all private sector",
+            "local authority",
+            "housing association",
+            "all social sector",
+            "all tenures",
+        ]
+        percentage_start_index = (
+            table_df[table_df["tenure"] == "all tenures"].index[0] + 1
+        )
+        sample_size_start_index = (
+            table_df[table_df["tenure"] == "all tenures"].index[1] + 1
+        )
+        for idx in table_df.index:
+            if idx >= percentage_start_index and idx < sample_size_start_index:
+                unit = "percentages"
+            elif idx >= sample_size_start_index:
+                unit = "dwellings"
+            else:
+                unit = "thousands of dwellings"
+            table_df.loc[idx, "unit"] = unit
+
+        table_df = (
+            rename_columns(
+                dataframe=table_df,
+                table_name=sheet_name,
+                column_map={
+                    "backboiler": "back boiler",
+                    "noboiler": "no boiler",
+                    "samplesize": "sample size",
+                },
+            )
+            .pipe(
+                melt_dataframe,
+                table_name=sheet_name,
+                id_vars=["tenure", "unit"],
+                value_name="value",
+                var_name="variable",
+            )
+            .pipe(
+                replace_value_in_column,
+                table_name=sheet_name,
+                column_name="value",
+                replaced_value="u",  # disclosive, findings derived from unweighted cell counts of <5 and >0
+                replacement_value=None,
+            )
+        )
+
+        # Drop redundant rows
+        table_df = drop_duplicate_rows(
+            dataframe=table_df,
+            table_name=sheet_name,
+            consider_columns=["tenure", "variable", "value"],
+            keep=False,
+        ).pipe(
+            drop_duplicate_rows,
+            table_name=sheet_name,
+            consider_columns=["tenure", "unit", "value"],
+            keep=False,
+        )
+
+        table_df = assert_dtypes(
+            dataframe=table_df,
+            table_name=sheet_name,
+            expected_dtypes=table_dict.get("dtypes"),
+        )
+
+    transformed_tables[sheet_name] = table_df
+
+# %%
+# # Load to s3 with transformation log as metadata
+s3_file_path = []
+for name, dataframe in transformed_tables.items():
+
+    metadata = {}
+    with open(log_file_path, "r") as log_file:
+        i = 1
+        for line in log_file:
+            if name in line:
+                metadata[f"bronze_to_silver_transformation_{i}"] = line
+                i = i + 1
+
+    # Encode metadata to parquet metadata via DataFrame attrs property
+    dataframe.attrs = metadata
+
+    # Get corresponding file url of table
+    for dict in latest_version.get("tables"):
+        if dict["sheet_name"] == name:
+            file_url = dict["file_url"]
+
+    file_path = save_to_s3_silver(
+        dataframe=dataframe,
+        dataset_name=dataset_name,
+        main_file_dict=latest_version,
+        file_url_index=latest_version["file_url"].index(file_url),
+        subset_id=name,
+    )
+    s3_file_path.append(file_path)
+
+# %%
+# Append "file_silver" to config
+if not s3_file_path:
+    pass
+else:
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_silver",
+    )

--- a/asf_mission_data_tool/pipeline/english_housing_survey_pipeline/get_english_housing_survey_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/english_housing_survey_pipeline/get_english_housing_survey_to_bronze.py
@@ -1,0 +1,24 @@
+from asf_mission_data_tool.getters.data_getters import (
+    save_to_s3_bronze,
+    get_latest_version,
+    append_field_to_latest_version,
+)
+
+dataset_name = "english_housing_survey"
+
+latest_version = get_latest_version(dataset_name)
+
+s3_file_path = []
+for file_url in latest_version.get("file_url"):
+    file_path = save_to_s3_bronze(dataset_name=dataset_name, target_url=file_url)
+    if file_path:
+        s3_file_path.append(file_path)
+
+if not s3_file_path:
+    pass
+else:
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_bronze",
+    )

--- a/asf_mission_data_tool/pipeline/fuel_poverty_statistics/bronze_to_silver_fuel_poverty_statistics.py
+++ b/asf_mission_data_tool/pipeline/fuel_poverty_statistics/bronze_to_silver_fuel_poverty_statistics.py
@@ -1,0 +1,637 @@
+# %%
+import pandas as pd
+
+# %%
+from asf_mission_data_tool.getters.data_getters import (
+    get_from_s3,
+    save_to_s3_silver,
+    append_field_to_latest_version,
+    get_latest_version,
+)
+
+# %%
+from asf_mission_data_tool.getters.bronze_to_silver_transformations import (
+    set_logger,
+)
+
+# %%
+from asf_mission_data_tool.getters.bronze_to_silver_transformations import (
+    drop_nan_rows,
+    drop_row,
+    melt_dataframe,
+    rename_columns,
+    assert_dtypes,
+    add_constant_column,
+    remove_line_break_chars,
+    remove_special_chars,
+    forward_fill_nan_by_column,
+    replace_value_in_column,
+    forward_backward_fill_nan_by_column,
+    drop_duplicate_rows,
+)
+
+# %%
+# Dataset specific variables
+dataset_name = "fuel_poverty_statistics"
+latest_version = get_latest_version(dataset_name)
+log_file_path = dataset_name + ".log"
+
+# %%
+# Set up logger for transformation tracking
+set_logger(log_file_path)
+
+# %%
+# Download file content from s3
+latest_version_bronze_key = (
+    get_latest_version(dataset_name)
+    .get("file_bronze")[0]
+    .replace("s3://asf-mission-data-tool/", "")
+)
+content = get_from_s3(s3_key=latest_version_bronze_key)
+
+# %%
+# Check table-level information is available
+tables = latest_version.get("tables")
+if not tables:
+    raise ValueError("No 'tables' key found in config, or 'tables' is empty.")
+
+# %%
+# Read and series transformations for each table in dataset
+transformed_tables = {}
+for table_dict in latest_version.get("tables"):
+
+    # Extract information
+    sheet_name = table_dict.get("sheet_name")
+    if not sheet_name:
+        raise ValueError("Missing 'sheet_name' in table data.")
+    skiprows = table_dict.get("skiprows")
+    if not skiprows:
+        raise ValueError("Missing 'skiprows' in table data.")
+
+    # Raise error if more tables are added
+    if sheet_name not in [
+        "Table 1",  # By all households and vulnerable households
+        "Table 2",  # By quadrant of Low Income Low Energy Efficiency matrix
+        "Table 3",  # By Fuel Poverty Energy Efficiency Rating FPEER
+        "Table 5",  # By rurality and FPEER
+        "Table 6",  # By region
+        "Table 7",  # By dwelling type
+        "Table 8",  # By age of dwelling
+        "Table 9",  # By floor area
+        "Table 10",  # By gas grid connection and FPEER
+        "Table 11",  # By central heating and FPEER
+        "Table 12",  # By main fuel type and FPEER
+        "Table 13",  # By central heating and main fuel
+        "Table 14",  # By boiler type
+        "Table 15",  # By wall insulation and FPEER
+        "Table 16",  # By wall type and gas grid connection
+        "Table 17",  # By loft insulation
+        "Table 18",  # By renewable heat technology and FPEER
+        "Table 19",  # By tenure and FPEER
+        "Table 20",  # By housing sector
+        "Table 24",  # By number of people in household
+        "Table 29",  # By tenure and vulnerability
+        "Table 31",  # By income decile and FPEER
+        "Table 32",  # By gas payment method
+        "Table 33",  # By electricity payment method
+        "Table 34",  # By in receipt of benefits
+        "Table 35",  # By ECO4 Help to Heat Group eligibility
+    ]:
+        raise ValueError(
+            "New tables have been added that are not currently accounted for in pipeline."
+        )
+
+    table_df = pd.read_excel(content, sheet_name=sheet_name, skiprows=skiprows)
+
+    # Layout type: Two separate tables with same fields but different household groups
+    if sheet_name == "Table 1":
+
+        table_df = drop_nan_rows(
+            dataframe=table_df, table_name=sheet_name, threshold=3
+        ).reset_index(drop=True)
+
+        table_df["category"] = [
+            "All households",
+            "All households",
+            "All households",
+            "Vulnerable households only",
+            "Vulnerable households only",
+            "Vulnerable households only",
+            "Vulnerable households only",
+        ]
+
+        row_to_drop = (
+            table_df["All households"].to_list().index("Vulnerable households only")
+        )
+        table_df = drop_row(
+            dataframe=table_df, table_name=sheet_name, index_list_to_drop=row_to_drop
+        )
+
+        table_df = (
+            melt_dataframe(
+                dataframe=table_df,
+                table_name=sheet_name,
+                id_vars=["category", "All households"],
+                value_name="value",
+            )
+            .pipe(drop_nan_rows, table_name=sheet_name, threshold=4)
+            .reset_index(drop=True)
+            .pipe(
+                rename_columns,
+                table_name=sheet_name,
+                column_map={"All households": "group"},
+            )
+            .pipe(
+                assert_dtypes,
+                table_name=sheet_name,
+                expected_dtypes=table_dict.get("dtypes"),
+            )
+        )
+
+    # Layout type: Single table
+    if sheet_name in [
+        "Table 2",
+        "Table 3",
+        "Table 6",
+        "Table 7",
+        "Table 8",
+        "Table 9",
+        "Table 14",
+        "Table 17",
+        "Table 20",
+        "Table 24",
+        "Table 32",
+        "Table 33",
+        "Table 35",
+    ]:
+        category_name = table_df.columns.to_list()[0]
+        table_df = (
+            drop_nan_rows(dataframe=table_df, table_name=sheet_name, threshold=2)
+            .reset_index(drop=True)
+            .pipe(
+                add_constant_column,
+                table_name=sheet_name,
+                column_name="category",
+                constant_value=category_name,
+            )
+            .pipe(
+                melt_dataframe,
+                table_name=sheet_name,
+                id_vars=["category", category_name],
+                value_name="value",
+            )
+            .pipe(
+                rename_columns,
+                table_name=sheet_name,
+                column_map={category_name: "group"},
+            )
+            .pipe(
+                remove_line_break_chars,
+                table_name=sheet_name,
+                column_to_clean="category",
+            )
+            .pipe(
+                remove_special_chars,
+                table_name=sheet_name,
+                column_to_clean="value",
+                char_to_remove=r"\^",  # ^ Numbers based on a low sample count (between 10 and less than 30) have been marked with ^. Inferences should not be made on this figure.
+            )
+            .pipe(
+                replace_value_in_column,
+                table_name=sheet_name,
+                column_name="value",
+                replaced_value="*",  # * Numbers based on very low sample count (less than 10) have been hidden with *.
+                replacement_value=0.0,
+            )
+            .pipe(
+                assert_dtypes,
+                table_name=sheet_name,
+                expected_dtypes=table_dict.get("dtypes"),
+            )
+        )
+
+    # Layout type: Two tables with total and type breakdown in second table
+    if sheet_name in [
+        "Table 5",
+        "Table 10",
+        "Table 11",
+        "Table 12",
+        "Table 18",
+        "Table 31",
+    ]:
+        category_1_name = table_df.columns.to_list()[0]
+        table_df = (
+            drop_nan_rows(dataframe=table_df, table_name=sheet_name, threshold=2)
+            .reset_index(drop=True)
+            .pipe(
+                forward_fill_nan_by_column,
+                table_name=sheet_name,
+                column_name=category_1_name,
+            )
+        )
+
+        # Read full table only
+        drop_row_lookup = {
+            "Table 5": 4,
+            "Table 10": 3,
+            "Table 11": 4,
+            "Table 12": 4,
+            "Table 18": 3,
+            "Table 31": 5,
+        }
+        table_df = table_df.iloc[drop_row_lookup.get(sheet_name) :].reset_index(
+            drop=True
+        )
+        table_df.columns = table_df.iloc[0]
+        table_df = table_df.drop(index=0).reset_index(drop=True)
+
+        category_2_name = table_df.columns.to_list()[1]
+        table_df = (
+            melt_dataframe(
+                dataframe=table_df,
+                table_name=sheet_name,
+                id_vars=[category_1_name, category_2_name],
+                value_name="value",
+                var_name="variable",
+            )
+            .pipe(
+                remove_special_chars,
+                table_name=sheet_name,
+                column_to_clean="value",
+                char_to_remove=r"\^",  # ^ Numbers based on a low sample count (between 10 and less than 30) have been marked with ^. Inferences should not be made on this figure.
+            )
+            .pipe(
+                remove_special_chars,
+                table_name=sheet_name,
+                column_to_clean="value",
+                char_to_remove=r"\,",
+            )
+            .pipe(
+                replace_value_in_column,
+                table_name=sheet_name,
+                column_name="value",
+                replaced_value="*",  # * Numbers based on very low sample count (less than 10) have been hidden with *.
+                replacement_value=0.0,
+            )
+            .pipe(
+                assert_dtypes,
+                table_name=sheet_name,
+                expected_dtypes=table_dict.get("dtypes"),
+            )
+        )
+
+    # Layout type: Single table with type breakdown
+    if sheet_name in ["Table 13", "Table 16"]:
+        category_1_name = table_df.columns.to_list()[0]
+        category_2_name = table_df.columns.to_list()[1]
+        table_df = (
+            drop_nan_rows(dataframe=table_df, table_name=sheet_name, threshold=3)
+            .reset_index(drop=True)
+            .pipe(
+                forward_fill_nan_by_column,
+                table_name=sheet_name,
+                column_name=category_1_name,
+            )
+            .pipe(
+                melt_dataframe,
+                table_name=sheet_name,
+                id_vars=[category_1_name, category_2_name],
+                value_name="value",
+                var_name="variable",
+            )
+            .pipe(
+                remove_special_chars,
+                table_name=sheet_name,
+                column_to_clean="value",
+                char_to_remove=r"\^",  # ^ Numbers based on a low sample count (between 10 and less than 30) have been marked with ^. Inferences should not be made on this figure.
+            )
+            .pipe(
+                remove_special_chars,
+                table_name=sheet_name,
+                column_to_clean="value",
+                char_to_remove=r"\,",
+            )
+            .pipe(
+                replace_value_in_column,
+                table_name=sheet_name,
+                column_name="value",
+                replaced_value="*",  # * Numbers based on very low sample count (less than 10) have been hidden with *.
+                replacement_value=0.0,
+            )
+            .pipe(
+                assert_dtypes,
+                table_name=sheet_name,
+                expected_dtypes=table_dict.get("dtypes"),
+            )
+        )
+
+    # Layout type: Two tables with total and type breakdown in second table
+    # Table 15 treated differently due to [Note A]/[Note B] difference in first column header
+    if sheet_name in ["Table 15"]:
+        category_1_name = table_df.columns.to_list()[0]
+        table_df = (
+            drop_nan_rows(dataframe=table_df, table_name=sheet_name, threshold=2)
+            .reset_index(drop=True)
+            .pipe(
+                forward_fill_nan_by_column,
+                table_name=sheet_name,
+                column_name=category_1_name,
+            )
+        )
+
+        # Read full table only
+        table_df = table_df.iloc[6:].reset_index(drop=True)
+        table_df.columns = table_df.iloc[0]
+        table_df = table_df.drop(index=0).reset_index(drop=True)
+
+        category_1_name = table_df.columns.to_list()[0]
+        category_2_name = table_df.columns.to_list()[1]
+
+        table_df = (
+            melt_dataframe(
+                dataframe=table_df,
+                table_name=sheet_name,
+                id_vars=[category_1_name, category_2_name],
+                value_name="value",
+                var_name="variable",
+            )
+            .pipe(
+                remove_special_chars,
+                table_name=sheet_name,
+                column_to_clean="value",
+                char_to_remove=r"\^",  # ^ Numbers based on a low sample count (between 10 and less than 30) have been marked with ^. Inferences should not be made on this figure.
+            )
+            .pipe(
+                remove_special_chars,
+                table_name=sheet_name,
+                column_to_clean="value",
+                char_to_remove=r"\,",
+            )
+            .pipe(
+                replace_value_in_column,
+                table_name=sheet_name,
+                column_name="value",
+                replaced_value="*",  # * Numbers based on very low sample count (less than 10) have been hidden with *.
+                replacement_value=0.0,
+            )
+            .pipe(
+                rename_columns,
+                table_name=sheet_name,
+                column_map={"Wall insulation\n[Note B]": "Wall insulation [Note B]"},
+            )
+            .pipe(
+                assert_dtypes,
+                table_name=sheet_name,
+                expected_dtypes=table_dict.get("dtypes"),
+            )
+        )
+
+    # Layout type: Three tables with total and most dissagregated type breakdown in third table
+    if sheet_name in ["Table 19"]:
+        category_1_name = table_df.columns.to_list()[0]
+        table_df = (
+            drop_nan_rows(dataframe=table_df, table_name=sheet_name, threshold=2)
+            .reset_index(drop=True)
+            .pipe(
+                forward_fill_nan_by_column,
+                table_name=sheet_name,
+                column_name=category_1_name,
+            )
+        )
+
+        # Read full table only
+        table_df = table_df.iloc[21:].reset_index(drop=True)
+        table_df.columns = table_df.iloc[0]
+        table_df = table_df.drop(index=0).reset_index(drop=True)
+
+        category_1_name = table_df.columns.to_list()[0]
+        category_2_name = table_df.columns.to_list()[1]
+
+        table_df = (
+            melt_dataframe(
+                dataframe=table_df,
+                table_name=sheet_name,
+                id_vars=[category_1_name, category_2_name],
+                value_name="value",
+                var_name="variable",
+            )
+            .pipe(
+                remove_special_chars,
+                table_name=sheet_name,
+                column_to_clean="value",
+                char_to_remove=r"\^",  # ^ Numbers based on a low sample count (between 10 and less than 30) have been marked with ^. Inferences should not be made on this figure.
+            )
+            .pipe(
+                remove_special_chars,
+                table_name=sheet_name,
+                column_to_clean="value",
+                char_to_remove=r"\,",
+            )
+            .pipe(
+                replace_value_in_column,
+                table_name=sheet_name,
+                column_name="value",
+                replaced_value="*",  # * Numbers based on very low sample count (less than 10) have been hidden with *.
+                replacement_value=0.0,
+            )
+            .pipe(
+                rename_columns,
+                table_name=sheet_name,
+                column_map={"Tenure\n[Note A]": "Tenure [Note A]"},
+            )
+            .pipe(
+                replace_value_in_column,
+                table_name=sheet_name,
+                column_name="Tenure [Note A]",
+                replaced_value="Housing association",
+                replacement_value="Housing association (Registered Social Landlords)",  # Note A
+            )
+            .pipe(
+                assert_dtypes,
+                table_name=sheet_name,
+                expected_dtypes=table_dict.get("dtypes"),
+            )
+        )
+
+    # Layout type: Single table with type breakdown
+    # Table 29 treated differently due to label formatting difference in first column
+    if sheet_name in ["Table 29"]:
+        category_1_name = table_df.columns.to_list()[0]
+        category_2_name = table_df.columns.to_list()[1]
+        table_df = (
+            drop_nan_rows(dataframe=table_df, table_name=sheet_name, threshold=3)
+            .reset_index(drop=True)
+            .pipe(
+                forward_backward_fill_nan_by_column,
+                table_name=sheet_name,
+                column_name=category_1_name,
+                limit=1,
+            )
+            .pipe(
+                melt_dataframe,
+                table_name=sheet_name,
+                id_vars=[category_1_name, category_2_name],
+                value_name="value",
+                var_name="variable",
+            )
+            .pipe(
+                remove_special_chars,
+                table_name=sheet_name,
+                column_to_clean="value",
+                char_to_remove=r"\^",  # ^ Numbers based on a low sample count (between 10 and less than 30) have been marked with ^. Inferences should not be made on this figure.
+            )
+            .pipe(
+                remove_special_chars,
+                table_name=sheet_name,
+                column_to_clean="value",
+                char_to_remove=r"\,",
+            )
+            .pipe(
+                replace_value_in_column,
+                table_name=sheet_name,
+                column_name="value",
+                replaced_value="*",  # * Numbers based on very low sample count (less than 10) have been hidden with *.
+                replacement_value=0.0,
+            )
+            .pipe(
+                assert_dtypes,
+                table_name=sheet_name,
+                expected_dtypes=table_dict.get("dtypes"),
+            )
+        )
+
+    # Layout type: Two single breakdown tables, both to be read
+    if sheet_name in ["Table 34"]:
+        category_1_name = table_df.columns.to_list()[0]
+        table_df = drop_nan_rows(
+            dataframe=table_df, table_name=sheet_name, threshold=2
+        ).reset_index(drop=True)
+
+        table_df["category"] = [
+            "In receipt of benefits - excluding disability benefits",
+            "In receipt of benefits - excluding disability benefits",
+            "All households",
+            "In receipt of benefits - including disability benefits",
+            "In receipt of benefits - including disability benefits",
+            "In receipt of benefits - including disability benefits",
+            "All households",
+        ]
+
+        row_to_drop = (
+            table_df[category_1_name]
+            .to_list()
+            .index("In receipt of benefits - including disability benefits")
+        )
+        table_df = drop_row(
+            dataframe=table_df, table_name=sheet_name, index_list_to_drop=row_to_drop
+        )
+
+        table_df = (
+            melt_dataframe(
+                dataframe=table_df,
+                table_name=sheet_name,
+                id_vars=[
+                    "category",
+                    category_1_name,
+                ],
+                value_name="value",
+            )
+            .pipe(drop_nan_rows, table_name=sheet_name, threshold=4)
+            .reset_index(drop=True)
+            .pipe(
+                rename_columns,
+                table_name=sheet_name,
+                column_map={category_1_name: "group"},
+            )
+            .pipe(
+                drop_duplicate_rows,
+                table_name=sheet_name,
+            )
+            .pipe(
+                remove_special_chars,
+                table_name=sheet_name,
+                column_to_clean="value",
+                char_to_remove=r"\^",  # ^ Numbers based on a low sample count (between 10 and less than 30) have been marked with ^. Inferences should not be made on this figure.
+            )
+            .pipe(
+                replace_value_in_column,
+                table_name=sheet_name,
+                column_name="value",
+                replaced_value="*",  # * Numbers based on very low sample count (less than 10) have been hidden with *.
+                replacement_value=0.0,
+            )
+            .pipe(
+                assert_dtypes,
+                table_name=sheet_name,
+                expected_dtypes=table_dict.get("dtypes"),
+            )
+        )
+
+    transformed_tables[sheet_name] = table_df
+
+# %%
+# Create table to name lookup for subset id
+table_name_lookup = {
+    "Table 1": " by all households and vulnerable households",
+    "Table 2": " by quadrant of lileee matrix",
+    "Table 3": " by fuel poverty energy efficiency rating fpeer",
+    "Table 5": " by rurality and fpeer",
+    "Table 6": " by region",
+    "Table 7": " by dwelling type",
+    "Table 8": " by age of dwelling",
+    "Table 9": " by floor area",
+    "Table 10": " by gas grid connection and fpeer",
+    "Table 11": " by central heating and fpeer",
+    "Table 12": " by main fuel type and fpeer",
+    "Table 13": " by central heating and fuel",
+    "Table 14": " by boiler type",
+    "Table 15": " by wall insulation and fpeer",
+    "Table 16": " by wall type and gas grid connection",
+    "Table 17": " by loft insulation",
+    "Table 18": " by renewable heat technology and fpeer",
+    "Table 19": " by tenure and fpeer",
+    "Table 20": " by housing sector",
+    "Table 24": " by household size",
+    "Table 29": " by tenure and vulnerability",
+    "Table 31": " by income decile and fpeer",
+    "Table 32": " by gas payment method",
+    "Table 33": " by electricity payment method",
+    "Table 34": " by benefit receipt",
+    "Table 35": " by eco4 hthg eligibility",
+}
+
+# %%
+# Load to s3 with transformation log as metadata
+s3_file_path = []
+for name, dataframe in transformed_tables.items():
+
+    metadata = {}
+    with open(log_file_path, "r") as log_file:
+        i = 1
+        for line in log_file:
+            if f"'{name}'" in line:
+                metadata[f"bronze_to_silver_transformation_{i}"] = line
+                i = i + 1
+
+    # Encode metadata to parquet metadata via DataFrame attrs property
+    dataframe.attrs = metadata
+
+    file_path = save_to_s3_silver(
+        dataframe=dataframe,
+        dataset_name=dataset_name,
+        main_file_dict=latest_version,
+        file_url_index=0,
+        subset_id=(name + table_name_lookup.get(name)).replace(" ", "_"),
+    )
+    s3_file_path.append(file_path)
+
+# %%
+# Append "file_silver" to config
+if not s3_file_path:
+    pass
+else:
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_silver",
+    )

--- a/asf_mission_data_tool/pipeline/fuel_poverty_statistics/get_fuel_poverty_statistics_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/fuel_poverty_statistics/get_fuel_poverty_statistics_to_bronze.py
@@ -1,0 +1,22 @@
+from asf_mission_data_tool.getters.data_getters import (
+    save_to_s3_bronze,
+    get_latest_version,
+    append_file_bronze_to_latest_version,
+)
+
+dataset_name = "fuel_poverty_statistics"
+
+latest_version = get_latest_version(dataset_name)
+
+s3_file_path = []
+for file_url in latest_version.get("file_url"):
+    file_path = save_to_s3_bronze(dataset_name=dataset_name, target_url=file_url)
+    if file_path:
+        s3_file_path.append(file_path)
+
+if not s3_file_path:
+    pass
+else:
+    append_file_bronze_to_latest_version(
+        dataset_name=dataset_name, s3_file_path=s3_file_path
+    )

--- a/asf_mission_data_tool/pipeline/fuel_poverty_statistics/get_fuel_poverty_statistics_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/fuel_poverty_statistics/get_fuel_poverty_statistics_to_bronze.py
@@ -1,7 +1,7 @@
 from asf_mission_data_tool.getters.data_getters import (
     save_to_s3_bronze,
     get_latest_version,
-    append_file_bronze_to_latest_version,
+    append_field_to_latest_version,
 )
 
 dataset_name = "fuel_poverty_statistics"
@@ -17,6 +17,8 @@ for file_url in latest_version.get("file_url"):
 if not s3_file_path:
     pass
 else:
-    append_file_bronze_to_latest_version(
-        dataset_name=dataset_name, s3_file_path=s3_file_path
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_bronze",
     )

--- a/asf_mission_data_tool/pipeline/future_energy_scenarios_pipeline/get_future_energy_scenarios_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/future_energy_scenarios_pipeline/get_future_energy_scenarios_to_bronze.py
@@ -1,0 +1,22 @@
+from asf_mission_data_tool.getters.data_getters import (
+    save_to_s3_bronze,
+    get_latest_version,
+    append_file_bronze_to_latest_version,
+)
+
+dataset_name = "future_energy_scenarios"
+
+latest_version = get_latest_version(dataset_name)
+
+s3_file_path = []
+for file_url in latest_version.get("file_url"):
+    file_path = save_to_s3_bronze(dataset_name=dataset_name, target_url=file_url)
+    if file_path:
+        s3_file_path.append(file_path)
+
+if not s3_file_path:
+    pass
+else:
+    append_file_bronze_to_latest_version(
+        dataset_name=dataset_name, s3_file_path=s3_file_path
+    )

--- a/asf_mission_data_tool/pipeline/future_energy_scenarios_pipeline/get_future_energy_scenarios_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/future_energy_scenarios_pipeline/get_future_energy_scenarios_to_bronze.py
@@ -1,7 +1,7 @@
 from asf_mission_data_tool.getters.data_getters import (
     save_to_s3_bronze,
     get_latest_version,
-    append_file_bronze_to_latest_version,
+    append_field_to_latest_version,
 )
 
 dataset_name = "future_energy_scenarios"
@@ -17,6 +17,8 @@ for file_url in latest_version.get("file_url"):
 if not s3_file_path:
     pass
 else:
-    append_file_bronze_to_latest_version(
-        dataset_name=dataset_name, s3_file_path=s3_file_path
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_bronze",
     )

--- a/asf_mission_data_tool/pipeline/heat_pump_deployment_quarterly_statistics_pipeline/bronze_to_silver_heat_pump_deployment_quarterly_statistics.py
+++ b/asf_mission_data_tool/pipeline/heat_pump_deployment_quarterly_statistics_pipeline/bronze_to_silver_heat_pump_deployment_quarterly_statistics.py
@@ -1,0 +1,132 @@
+import pandas as pd
+
+from asf_mission_data_tool.getters.data_getters import (
+    get_from_s3,
+    save_to_s3_silver,
+    append_field_to_latest_version,
+    get_latest_version,
+)
+
+from asf_mission_data_tool.getters.bronze_to_silver_transformations import (
+    set_logger,
+    standardise_column_names,
+    check_missing_values,
+    assert_dtypes,
+    expand_quarter_string,
+    melt_dataframe,
+    rename_columns,
+)
+
+# Dataset specific variables
+dataset_name = "heat_pump_deployment_quarterly_statistics"
+latest_version = get_latest_version(dataset_name)
+log_file_path = dataset_name + ".log"
+
+# Set up logger for transformation tracking
+set_logger(log_file_path)
+
+# Download file content from s3
+latest_version_bronze_key = (
+    get_latest_version(dataset_name)
+    .get("file_bronze")[0]
+    .replace("s3://asf-mission-data-tool/", "")
+)
+content = get_from_s3(s3_key=latest_version_bronze_key)
+
+# Check table-level information is available
+tables = latest_version.get("tables")
+if not tables:
+    raise ValueError("No 'tables' key found in config, or 'tables' is empty.")
+
+# Read and series transformations for each table in dataset
+transformed_tables = {}
+for table_dict in latest_version.get("tables"):
+
+    # Extract information
+    sheet_name = table_dict.get("sheet_name")
+    if not sheet_name:
+        raise ValueError("Missing 'sheet_name' in table data.")
+    skiprows = table_dict.get("skiprows")
+    if not skiprows:
+        raise ValueError("Missing 'skiprows' in table data.")
+
+    # Raise error if more tables are added
+    if sheet_name not in ["Table 1.1", "Table 1.2", "Table 1.3"]:
+        raise ValueError(
+            "New tables have been added that are not currently accounted for in pipeline."
+        )
+
+    type_lookup = {
+        "Table 1.1": "government_scheme",
+        "Table 1.2": "technology_type",
+        "Table 1.3": "region",
+    }
+    column_map = {
+        "Installation quarter [note 4]": "installation_quarter",
+        "Year": "year",
+        "Start of quarter": "start_of_quarter",
+        "End of quarter": "end_of_quarter",
+        type_lookup.get(sheet_name): type_lookup.get(sheet_name),
+        "Installations": "installations",
+    }
+
+    table_df = (
+        pd.read_excel(content, sheet_name=sheet_name, skiprows=skiprows)
+        .pipe(standardise_column_names, table_name=sheet_name)
+        .pipe(check_missing_values, table_name=sheet_name)
+        .pipe(expand_quarter_string, table_name=sheet_name)
+        .pipe(
+            melt_dataframe,
+            table_name=sheet_name,
+            id_vars=[
+                "Installation quarter [note 4]",
+                "Year",
+                "Start of quarter",
+                "End of quarter",
+            ],
+            var_name=type_lookup.get(sheet_name),
+            value_name="Installations",
+        )
+        .pipe(rename_columns, table_name=sheet_name, column_map=column_map)
+        .pipe(
+            assert_dtypes,
+            table_name=sheet_name,
+            expected_dtypes=table_dict.get("dtypes"),
+        )
+    )
+    transformed_tables[sheet_name] = table_df
+
+# Load to s3 with transformation log as metadata
+s3_file_path = []
+for name, dataframe in transformed_tables.items():
+
+    metadata = {}
+    with open(log_file_path, "r") as log_file:
+        i = 1
+        for line in log_file:
+            if name in line:
+                metadata[f"bronze_to_silver_transformation_{i}"] = line
+                i = i + 1
+
+    # Encode metadata to parquet metadata via DataFrame attrs property
+    dataframe.attrs = metadata
+
+    file_path = save_to_s3_silver(
+        dataframe=dataframe,
+        dataset_name=dataset_name,
+        main_file_dict=latest_version,
+        file_url_index=0,
+        subset_id="Table_" + name.split(" ")[1].replace(".", "_"),
+    )
+    s3_file_path.append(file_path)
+
+
+# Append "file_silver" to config
+if not s3_file_path:
+    pass
+else:
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_silver",
+    )

--- a/asf_mission_data_tool/pipeline/heat_pump_deployment_quarterly_statistics_pipeline/get_heat_pump_deployment_quarterly_statistics_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/heat_pump_deployment_quarterly_statistics_pipeline/get_heat_pump_deployment_quarterly_statistics_to_bronze.py
@@ -1,0 +1,22 @@
+from asf_mission_data_tool.getters.data_getters import (
+    save_to_s3_bronze,
+    get_latest_version,
+    append_file_bronze_to_latest_version,
+)
+
+dataset_name = "heat_pump_deployment_quarterly_statistics"
+
+latest_version = get_latest_version(dataset_name)
+
+s3_file_path = []
+for file_url in latest_version.get("file_url"):
+    file_path = save_to_s3_bronze(dataset_name=dataset_name, target_url=file_url)
+    if file_path:
+        s3_file_path.append(file_path)
+
+if not s3_file_path:
+    pass
+else:
+    append_file_bronze_to_latest_version(
+        dataset_name=dataset_name, s3_file_path=s3_file_path
+    )

--- a/asf_mission_data_tool/pipeline/heat_pump_deployment_quarterly_statistics_pipeline/get_heat_pump_deployment_quarterly_statistics_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/heat_pump_deployment_quarterly_statistics_pipeline/get_heat_pump_deployment_quarterly_statistics_to_bronze.py
@@ -1,7 +1,7 @@
 from asf_mission_data_tool.getters.data_getters import (
     save_to_s3_bronze,
     get_latest_version,
-    append_file_bronze_to_latest_version,
+    append_field_to_latest_version,
 )
 
 dataset_name = "heat_pump_deployment_quarterly_statistics"
@@ -17,6 +17,8 @@ for file_url in latest_version.get("file_url"):
 if not s3_file_path:
     pass
 else:
-    append_file_bronze_to_latest_version(
-        dataset_name=dataset_name, s3_file_path=s3_file_path
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_bronze",
     )

--- a/asf_mission_data_tool/pipeline/heat_pump_deployment_quarterly_statistics_pipeline/update_heat_pump_deployment_quarterly_statistics.py
+++ b/asf_mission_data_tool/pipeline/heat_pump_deployment_quarterly_statistics_pipeline/update_heat_pump_deployment_quarterly_statistics.py
@@ -1,0 +1,23 @@
+from asf_mission_data_tool.getters.data_getters import (
+    get_page_url,
+    get_file_url,
+    get_release_date,
+    add_new_version,
+)
+
+dataset_name = "heat_pump_deployment_quarterly_statistics"
+page_link_text = "Heat pump deployment statistics:"
+file_type = ".xlsx"
+file_text = "Heat_pump_deployment_quarterly_statistics_United_Kingdom_"
+
+page_url = get_page_url(dataset_name=dataset_name, page_link_text=page_link_text)
+file_url = get_file_url(page_url=page_url, file_type=file_type, file_text=file_text)
+release_date = get_release_date(page_url)
+
+add_new_version(
+    dataset_name=dataset_name,
+    page_url=page_url,
+    file_url=file_url,
+    release_date=release_date,
+    filter=None,
+)

--- a/asf_mission_data_tool/pipeline/northern_ireland_statistics_and_research_agency_census/get_northern_ireland_statistics_and_research_agency_census_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/northern_ireland_statistics_and_research_agency_census/get_northern_ireland_statistics_and_research_agency_census_to_bronze.py
@@ -1,0 +1,22 @@
+from asf_mission_data_tool.getters.data_getters import (
+    save_to_s3_bronze,
+    get_latest_version,
+    append_file_bronze_to_latest_version,
+)
+
+dataset_name = "northern_ireland_statistics_and_research_agency_census"
+
+latest_version = get_latest_version(dataset_name)
+
+s3_file_path = []
+for file_url in latest_version.get("file_url"):
+    file_path = save_to_s3_bronze(dataset_name=dataset_name, target_url=file_url)
+    if file_path:
+        s3_file_path.append(file_path)
+
+if not s3_file_path:
+    pass
+else:
+    append_file_bronze_to_latest_version(
+        dataset_name=dataset_name, s3_file_path=s3_file_path
+    )

--- a/asf_mission_data_tool/pipeline/northern_ireland_statistics_and_research_agency_census/get_northern_ireland_statistics_and_research_agency_census_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/northern_ireland_statistics_and_research_agency_census/get_northern_ireland_statistics_and_research_agency_census_to_bronze.py
@@ -1,7 +1,7 @@
 from asf_mission_data_tool.getters.data_getters import (
     save_to_s3_bronze,
     get_latest_version,
-    append_file_bronze_to_latest_version,
+    append_field_to_latest_version,
 )
 
 dataset_name = "northern_ireland_statistics_and_research_agency_census"
@@ -17,6 +17,8 @@ for file_url in latest_version.get("file_url"):
 if not s3_file_path:
     pass
 else:
-    append_file_bronze_to_latest_version(
-        dataset_name=dataset_name, s3_file_path=s3_file_path
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_bronze",
     )

--- a/asf_mission_data_tool/pipeline/public_attitudes_tracking_survey_pipeline/bronze_to_silver_public_attitudes_tracking_survey.py
+++ b/asf_mission_data_tool/pipeline/public_attitudes_tracking_survey_pipeline/bronze_to_silver_public_attitudes_tracking_survey.py
@@ -1,0 +1,509 @@
+# %%
+import pandas as pd
+from datetime import datetime
+
+# %%
+from asf_mission_data_tool.getters.data_getters import (
+    get_from_s3,
+    save_to_s3_silver,
+    append_field_to_latest_version,
+    get_latest_version,
+)
+
+# %%
+from asf_mission_data_tool.getters.bronze_to_silver_transformations import (
+    set_logger,
+    add_constant_column,
+    melt_dataframe,
+    rename_columns,
+    remove_line_break_chars,
+    expand_wave_season_dates,
+    replace_nan_in_column,
+    replace_value_in_column,
+    assert_dtypes,
+)
+
+# %% [markdown]
+# ## Time series tables
+
+# %%
+dataset_name = "public_attitudes_tracking_survey"
+log_file_path = dataset_name + ".log"
+set_logger(log_file_path)
+
+# %% [markdown]
+# ### Winter
+
+# %%
+winter_latest_version = get_latest_version(dataset_name, filter="Winter")
+
+# %%
+# Download file content from s3
+winter_content = {}
+for file_url in [
+    url
+    for url in winter_latest_version.get("file_url", [])
+    if "time_series" in url.lower()
+]:
+    file_name = file_url.split("/")[-1]
+    bronze_key = [
+        file_bronze
+        for file_bronze in winter_latest_version.get("file_bronze")
+        if file_name in file_bronze
+    ][0].replace("s3://asf-mission-data-tool/", "")
+    winter_content[file_url] = get_from_s3(s3_key=bronze_key)
+
+# %%
+# Read all sheets into a dictionary of dataframes
+winter_sheets = pd.read_excel(winter_content[file_url], sheet_name=None)
+
+# Create question variable and full question lookup
+winter_question_lookup = {}
+for sheet in winter_sheets:
+    if sheet != "Table of contents":
+        winter_question_lookup[sheet] = winter_sheets[sheet].iloc[0, 0]
+
+# %%
+winter_sheets_transformed = {}
+for sheet_name in winter_question_lookup.keys():
+    df = winter_sheets[sheet_name]
+
+    # Drop redundant rows and set header row
+    df = df.iloc[7:].reset_index(drop=True)
+    df.columns = df.iloc[0]
+    df = df.drop(index=0)
+    df = df.reset_index(drop=True)
+
+    # Drop column for Total across all historical waves
+    df = df.drop("Total", axis=1)
+
+    # Add column for question label
+    df = (
+        add_constant_column(
+            dataframe=df,
+            table_name=f"winter/{sheet_name}",
+            column_name="question",
+            constant_value=winter_question_lookup[sheet_name],
+        )
+        .pipe(
+            melt_dataframe,
+            table_name=f"winter/{sheet_name}",
+            id_vars=[
+                "question",
+                "Subgroup identifier row",
+            ],
+            var_name="wave_season",
+            value_name="value",
+        )
+        .pipe(
+            rename_columns,
+            table_name=f"winter/{sheet_name}",
+            column_map={"Subgroup identifier row": "variable"},
+        )
+    )
+
+    # Add variable type column
+    df["variable_type"] = df["variable"].apply(
+        lambda x: (
+            "count" if x == "Unweighted Base" or x == "Weighted Base" else "proportion"
+        )
+    )
+
+    df = (
+        remove_line_break_chars(
+            dataframe=df,
+            table_name=f"winter/{sheet_name}",
+            column_to_clean="wave_season",
+        )
+        .pipe(
+            expand_wave_season_dates,
+            table_name=f"winter/{sheet_name}",
+            column_name="wave_season",
+        )
+        .pipe(
+            replace_nan_in_column,
+            table_name=f"winter/{sheet_name}",
+            column_name="value",
+            value=0,
+        )  # Where NA is used in the tables this denotes that the response was not given by any respondents.
+        .pipe(
+            replace_value_in_column,
+            table_name=f"winter/{sheet_name}",
+            column_name="value",
+            replaced_value="low",
+            replacement_value=0.5 / 100,
+        )  # Where low is used in the tables this denotes that the response was given by less than 0.5% of the sample.
+        .pipe(
+            assert_dtypes,
+            table_name=f"winter/{sheet_name}",
+            expected_dtypes=winter_latest_version.get("tables")[0].get("dtypes"),
+        )
+    )
+
+    winter_sheets_transformed[sheet_name] = df
+
+# Combine all question tables
+winter_master_table = pd.concat(
+    winter_sheets_transformed.values(), ignore_index=True
+).reset_index(drop=True)
+
+# Reorder columns
+winter_master_table = winter_master_table[
+    [
+        "question",
+        "wave_year",
+        "season_start_date",
+        "season_end_date",
+        "wave_season",
+        "variable",
+        "variable_type",
+        "value",
+    ]
+]
+
+# %% [markdown]
+# ### Spring
+
+# %%
+spring_latest_version = get_latest_version(dataset_name, filter="Spring")
+
+# %%
+# Download file content from s3
+spring_content = {}
+for file_url in [
+    url
+    for url in spring_latest_version.get("file_url", [])
+    if "time_series" in url.lower()
+]:
+    file_name = file_url.split("/")[-1]
+    bronze_key = [
+        file_bronze
+        for file_bronze in spring_latest_version.get("file_bronze")
+        if file_name in file_bronze
+    ][0].replace("s3://asf-mission-data-tool/", "")
+    spring_content[file_url] = get_from_s3(s3_key=bronze_key)
+
+# %%
+# Read all sheets into a dictionary of dataframes
+spring_sheets = pd.read_excel(spring_content[file_url], sheet_name=None)
+
+# Create question variable and full question lookup
+spring_question_lookup = {}
+for sheet in spring_sheets:
+    if sheet != "Table of contents":
+        spring_question_lookup[sheet] = spring_sheets[sheet].iloc[0, 0]
+
+# %%
+spring_sheets_transformed = {}
+for sheet_name in spring_question_lookup.keys():
+    df = spring_sheets[sheet_name]
+
+    # Drop redundant rows and set header row
+    df = df.iloc[7:].reset_index(drop=True)
+    df.columns = df.iloc[0]
+    df = df.drop(index=0)
+    df = df.reset_index(drop=True)
+
+    # Drop column for Total across all historical waves
+    df = df.drop("Total", axis=1)
+
+    # Add column for question label
+    df = (
+        add_constant_column(
+            dataframe=df,
+            table_name=f"spring/{sheet_name}",
+            column_name="question",
+            constant_value=spring_question_lookup[sheet_name],
+        )
+        .pipe(
+            melt_dataframe,
+            table_name=f"spring/{sheet_name}",
+            id_vars=[
+                "question",
+                "Subgroup identifier row",
+            ],
+            var_name="wave_season",
+            value_name="value",
+        )
+        .pipe(
+            rename_columns,
+            table_name=f"spring/{sheet_name}",
+            column_map={"Subgroup identifier row": "variable"},
+        )
+    )
+
+    # Add variable type column
+    df["variable_type"] = df["variable"].apply(
+        lambda x: (
+            "count" if x == "Unweighted Base" or x == "Weighted Base" else "proportion"
+        )
+    )
+
+    df = (
+        remove_line_break_chars(
+            dataframe=df,
+            table_name=f"spring/{sheet_name}",
+            column_to_clean="wave_season",
+        )
+        .pipe(
+            expand_wave_season_dates,
+            table_name=f"spring/{sheet_name}",
+            column_name="wave_season",
+        )
+        .pipe(
+            replace_nan_in_column,
+            table_name=f"spring/{sheet_name}",
+            column_name="value",
+            value=0,
+        )  # Where NA is used in the tables this denotes that the response was not given by any respondents.
+        .pipe(
+            replace_value_in_column,
+            table_name=f"spring/{sheet_name}",
+            column_name="value",
+            replaced_value="low",
+            replacement_value=0.5 / 100,
+        )  # Where low is used in the tables this denotes that the response was given by less than 0.5% of the sample.
+        .pipe(
+            assert_dtypes,
+            table_name=f"spring/{sheet_name}",
+            expected_dtypes=spring_latest_version.get("tables")[0].get("dtypes"),
+        )
+    )
+
+    spring_sheets_transformed[sheet_name] = df
+
+# Combine all question tables
+spring_master_table = pd.concat(
+    spring_sheets_transformed.values(), ignore_index=True
+).reset_index(drop=True)
+
+# Reorder columns
+spring_master_table = spring_master_table[
+    [
+        "question",
+        "wave_year",
+        "season_start_date",
+        "season_end_date",
+        "wave_season",
+        "variable",
+        "variable_type",
+        "value",
+    ]
+]
+
+# %% [markdown]
+# ### Summer
+
+# %%
+summer_latest_version = get_latest_version(dataset_name, filter="Summer")
+
+# %%
+# Download file content from s3
+summer_content = {}
+for file_url in [
+    url
+    for url in summer_latest_version.get("file_url", [])
+    if "time_series" in url.lower()
+]:
+    file_name = file_url.split("/")[-1]
+    bronze_key = [
+        file_bronze
+        for file_bronze in summer_latest_version.get("file_bronze")
+        if file_name in file_bronze
+    ][0].replace("s3://asf-mission-data-tool/", "")
+    summer_content[file_url] = get_from_s3(s3_key=bronze_key)
+
+# %%
+# Read all sheets into a dictionary of dataframes
+summer_sheets = pd.read_excel(summer_content[file_url], sheet_name=None)
+
+# Create question variable and full question lookup
+summer_question_lookup = {}
+for sheet in summer_sheets:
+    if sheet != "Table of contents":
+        summer_question_lookup[sheet] = summer_sheets[sheet].iloc[0, 0]
+
+# %%
+summer_sheets_transformed = {}
+for sheet_name in summer_question_lookup.keys():
+    df = summer_sheets[sheet_name]
+
+    # Drop redundant rows and set header row
+    df = df.iloc[7:].reset_index(drop=True)
+    df.columns = df.iloc[0]
+    df = df.drop(index=0)
+    df = df.reset_index(drop=True)
+
+    # Drop column for Total across all historical waves
+    df = df.drop("Total", axis=1)
+
+    # Add column for question label
+    df = (
+        add_constant_column(
+            dataframe=df,
+            table_name=f"summer/{sheet_name}",
+            column_name="question",
+            constant_value=summer_question_lookup[sheet_name],
+        )
+        .pipe(
+            melt_dataframe,
+            table_name=f"summer/{sheet_name}",
+            id_vars=[
+                "question",
+                "Subgroup identifier row",
+            ],
+            var_name="wave_season",
+            value_name="value",
+        )
+        .pipe(
+            rename_columns,
+            table_name=f"summer/{sheet_name}",
+            column_map={"Subgroup identifier row": "variable"},
+        )
+    )
+
+    # Add variable type column
+    df["variable_type"] = df["variable"].apply(
+        lambda x: (
+            "count" if x == "Unweighted Base" or x == "Weighted Base" else "proportion"
+        )
+    )
+
+    df = (
+        remove_line_break_chars(
+            dataframe=df,
+            table_name=f"summer/{sheet_name}",
+            column_to_clean="wave_season",
+        )
+        .pipe(
+            expand_wave_season_dates,
+            table_name=f"summer/{sheet_name}",
+            column_name="wave_season",
+        )
+        .pipe(
+            replace_nan_in_column,
+            table_name=f"summer/{sheet_name}",
+            column_name="value",
+            value=0,
+        )  # Where NA is used in the tables this denotes that the response was not given by any respondents.
+        .pipe(
+            replace_value_in_column,
+            table_name=f"summer/{sheet_name}",
+            column_name="value",
+            replaced_value="low",
+            replacement_value=0.5 / 100,
+        )  # Where low is used in the tables this denotes that the response was given by less than 0.5% of the sample.
+        .pipe(
+            assert_dtypes,
+            table_name=f"summer/{sheet_name}",
+            expected_dtypes=summer_latest_version.get("tables")[0].get("dtypes"),
+        )
+    )
+
+    summer_sheets_transformed[sheet_name] = df
+
+# Combine all question tables
+summer_master_table = pd.concat(
+    summer_sheets_transformed.values(), ignore_index=True
+).reset_index(drop=True)
+
+# Reorder columns
+summer_master_table = summer_master_table[
+    [
+        "question",
+        "wave_year",
+        "season_start_date",
+        "season_end_date",
+        "wave_season",
+        "variable",
+        "variable_type",
+        "value",
+    ]
+]
+
+# %% [markdown]
+# ### Uploading to s3
+
+# %%
+# Add transformation log as metadata
+
+winter_metadata = {}
+with open(log_file_path, "r") as log_file:
+    i = 1
+    for line in log_file:
+        if "winter" in line:
+            winter_metadata[f"bronze_to_silver_transformation_{i}_winter"] = line
+            i = i + 1
+winter_master_table.attrs = winter_metadata
+
+spring_metadata = {}
+with open(log_file_path, "r") as log_file:
+    i = 1
+    for line in log_file:
+        if "spring" in line:
+            spring_metadata[f"bronze_to_silver_transformation_{i}_spring"] = line
+            i = i + 1
+spring_master_table.attrs = spring_metadata
+
+summer_metadata = {}
+with open(log_file_path, "r") as log_file:
+    i = 1
+    for line in log_file:
+        if "summer" in line:
+            summer_metadata[f"bronze_to_silver_transformation_{i}_summer"] = line
+            i = i + 1
+summer_master_table.attrs = summer_metadata
+
+# %%
+# Upload to s3
+
+winter_silver_s3_file_path = save_to_s3_silver(
+    dataframe=winter_master_table,
+    dataset_name=dataset_name,
+    main_file_dict=winter_latest_version,
+    file_url_index=0,
+    subset_id="all_questions",
+)
+
+spring_silver_s3_file_path = save_to_s3_silver(
+    dataframe=spring_master_table,
+    dataset_name=dataset_name,
+    main_file_dict=spring_latest_version,
+    file_url_index=0,
+    subset_id="all_questions",
+)
+
+summer_silver_s3_file_path = save_to_s3_silver(
+    dataframe=summer_master_table,
+    dataset_name=dataset_name,
+    main_file_dict=summer_latest_version,
+    file_url_index=0,
+    subset_id="all_questions",
+)
+
+# %%
+# Append "file_silver" to config
+
+# Winter
+append_field_to_latest_version(
+    dataset_name=dataset_name,
+    s3_file_path=winter_silver_s3_file_path,
+    new_field_name="file_silver",
+    filter="Winter",
+)
+
+# Spring
+append_field_to_latest_version(
+    dataset_name=dataset_name,
+    s3_file_path=spring_silver_s3_file_path,
+    new_field_name="file_silver",
+    filter="Spring",
+)
+
+# Summer
+append_field_to_latest_version(
+    dataset_name=dataset_name,
+    s3_file_path=summer_silver_s3_file_path,
+    new_field_name="file_silver",
+    filter="Summer",
+)

--- a/asf_mission_data_tool/pipeline/public_attitudes_tracking_survey_pipeline/get_public_attitudes_tracking_survey_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/public_attitudes_tracking_survey_pipeline/get_public_attitudes_tracking_survey_to_bronze.py
@@ -1,0 +1,25 @@
+from asf_mission_data_tool.getters.data_getters import (
+    save_to_s3_bronze,
+    get_latest_version,
+    append_file_bronze_to_latest_version,
+)
+
+dataset_name = "public_attitudes_tracking_survey"
+
+# PAT is a triannual survey, get version for latest Summer/Spring/Winter
+
+for season in ["Summer", "Spring", "Winter"]:
+    latest_season_version = get_latest_version(dataset_name=dataset_name, filter=season)
+
+    s3_file_path = []
+    for url in latest_season_version.get("file_url"):
+        file_path = save_to_s3_bronze(dataset_name=dataset_name, target_url=url)
+        if file_path:
+            s3_file_path.append(file_path)
+
+        if not s3_file_path:
+            pass
+        else:
+            append_file_bronze_to_latest_version(
+                dataset_name=dataset_name, filter=season, s3_file_path=s3_file_path
+            )

--- a/asf_mission_data_tool/pipeline/public_attitudes_tracking_survey_pipeline/get_public_attitudes_tracking_survey_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/public_attitudes_tracking_survey_pipeline/get_public_attitudes_tracking_survey_to_bronze.py
@@ -1,7 +1,7 @@
 from asf_mission_data_tool.getters.data_getters import (
     save_to_s3_bronze,
     get_latest_version,
-    append_file_bronze_to_latest_version,
+    append_field_to_latest_version,
 )
 
 dataset_name = "public_attitudes_tracking_survey"
@@ -20,6 +20,9 @@ for season in ["Summer", "Spring", "Winter"]:
         if not s3_file_path:
             pass
         else:
-            append_file_bronze_to_latest_version(
-                dataset_name=dataset_name, filter=season, s3_file_path=s3_file_path
+            append_field_to_latest_version(
+                dataset_name=dataset_name,
+                filter=season,
+                s3_file_path=s3_file_path,
+                new_field_name="file_bronze",
             )

--- a/asf_mission_data_tool/pipeline/public_attitudes_tracking_survey_pipeline/update_public_attitudes_tracking_survey.py
+++ b/asf_mission_data_tool/pipeline/public_attitudes_tracking_survey_pipeline/update_public_attitudes_tracking_survey.py
@@ -1,0 +1,30 @@
+from asf_mission_data_tool.getters.data_getters import (
+    get_page_url,
+    get_file_url,
+    get_release_date,
+    add_new_version,
+)
+
+dataset_name = "public_attitudes_tracking_survey"
+page_link_text = "DESNZ Public Attitudes Tracker:"
+file_type = ".xlsx"
+file_text = "DESNZ_Public_Attitudes_Tracker_"
+
+page_url = get_page_url(
+    dataset_name=dataset_name, page_link_text=page_link_text, page_link_index=1
+)
+file_url = get_file_url(page_url=page_url, file_type=file_type, file_text=file_text)
+release_date = get_release_date(page_url)
+
+seasons = ["winter", "spring", "summer"]
+for season in seasons:
+    if season in page_url:
+        filter = season
+
+add_new_version(
+    dataset_name=dataset_name,
+    page_url=page_url,
+    file_url=file_url,
+    release_date=release_date,
+    filter=None,
+)

--- a/asf_mission_data_tool/pipeline/scottish_house_condition_survey_pipeline/get_scottish_house_condition_survey_pipeline.py
+++ b/asf_mission_data_tool/pipeline/scottish_house_condition_survey_pipeline/get_scottish_house_condition_survey_pipeline.py
@@ -1,0 +1,22 @@
+from asf_mission_data_tool.getters.data_getters import (
+    save_to_s3_bronze,
+    get_latest_version,
+    append_file_bronze_to_latest_version,
+)
+
+dataset_name = "scottish_house_condition_survey"
+
+latest_version = get_latest_version(dataset_name)
+
+s3_file_path = []
+for file_url in latest_version.get("file_url"):
+    file_path = save_to_s3_bronze(dataset_name=dataset_name, target_url=file_url)
+    if file_path:
+        s3_file_path.append(file_path)
+
+if not s3_file_path:
+    pass
+else:
+    append_file_bronze_to_latest_version(
+        dataset_name=dataset_name, s3_file_path=s3_file_path
+    )

--- a/asf_mission_data_tool/pipeline/scottish_house_condition_survey_pipeline/get_scottish_house_condition_survey_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/scottish_house_condition_survey_pipeline/get_scottish_house_condition_survey_to_bronze.py
@@ -1,7 +1,7 @@
 from asf_mission_data_tool.getters.data_getters import (
     save_to_s3_bronze,
     get_latest_version,
-    append_file_bronze_to_latest_version,
+    append_field_to_latest_version,
 )
 
 dataset_name = "scottish_house_condition_survey"
@@ -17,6 +17,8 @@ for file_url in latest_version.get("file_url"):
 if not s3_file_path:
     pass
 else:
-    append_file_bronze_to_latest_version(
-        dataset_name=dataset_name, s3_file_path=s3_file_path
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_bronze",
     )

--- a/asf_mission_data_tool/pipeline/seventh_carbon_budget_pipeline/bronze_to_silver_seventh_carbon_budget.py
+++ b/asf_mission_data_tool/pipeline/seventh_carbon_budget_pipeline/bronze_to_silver_seventh_carbon_budget.py
@@ -1,0 +1,287 @@
+import pandas as pd
+
+from asf_mission_data_tool.getters.data_getters import (
+    get_from_s3,
+    save_to_s3_silver,
+    append_field_to_latest_version,
+    get_latest_version,
+)
+
+from asf_mission_data_tool.getters.bronze_to_silver_transformations import (
+    set_logger,
+    assert_dtypes,
+    drop_nan_columns,
+    drop_row,
+    add_constant_column,
+    melt_dataframe,
+    replace_nan_in_column,
+    convert_sign_of_abatement,
+    replace_value_in_column,
+    rename_columns,
+)
+
+# Dataset specific variables
+dataset_name = "seventh_carbon_budget"
+latest_version = get_latest_version(dataset_name)
+log_file_path = dataset_name + ".log"
+
+# Set up logger for transformation tracking
+set_logger(log_file_path)
+
+# Check table-level information is available
+tables = latest_version.get("tables")
+if not tables:
+    raise ValueError("No 'tables' key found in config, or 'tables' is empty.")
+
+# Download file content from s3
+content = {}
+for file_url in latest_version.get("file_url"):
+    file_name = file_url.split("/")[-1]
+    bronze_key = [
+        file_bronze
+        for file_bronze in latest_version.get("file_bronze")
+        if file_name in file_bronze
+    ][0].replace("s3://asf-mission-data-tool/", "")
+    content[file_url] = get_from_s3(s3_key=bronze_key)
+
+# Read and series transformations for each table in dataset
+transformed_tables = {}
+for table_dict in latest_version.get("tables"):
+
+    # Extract information
+    sheet_name = table_dict.get("sheet_name")
+    if not sheet_name:
+        raise ValueError("Missing 'sheet_name' in table data.")
+    file_url = table_dict.get("file_url")
+
+    # Raise error if more tables are added
+    if sheet_name not in [
+        "Economy-wide data",
+        "Sector-level data",
+        "Subsector-level data",
+        "Measure-level data",
+        "3.5",
+        "7.2.1",
+        "7.2.2",
+        "7.2.4",
+    ]:
+        raise ValueError(
+            "New tables have been added that are not currently accounted for in pipeline."
+        )
+
+    # Raw data tables
+    if sheet_name in [
+        "Economy-wide data",
+        "Sector-level data",
+        "Subsector-level data",
+        "Measure-level data",
+    ]:
+        table_df = pd.read_excel(content[file_url], sheet_name=sheet_name).pipe(
+            assert_dtypes,
+            table_name=sheet_name,
+            expected_dtypes=table_dict.get("dtypes"),
+        )
+
+    # Chart data tables
+    if sheet_name in ["3.5"]:  # Sources of abatement in Balanced Pathway
+
+        skiprows = table_dict.get("skiprows")
+        if not skiprows:
+            raise ValueError("Missing 'skiprows' in table data.")
+
+        redundant_rows = [0, 1, 2, 3, 20, 21, 22]
+
+        table_df = (
+            pd.read_excel(content[file_url], sheet_name=sheet_name, skiprows=skiprows)
+            .pipe(drop_nan_columns, table_name=sheet_name)
+            .pipe(drop_row, table_name=sheet_name, index_list_to_drop=redundant_rows)
+            .pipe(
+                add_constant_column,
+                table_name=sheet_name,
+                column_name="Pathway",
+                constant_value="Balanced Pathway",
+            )
+            .pipe(
+                melt_dataframe,
+                table_name=sheet_name,
+                id_vars=["Pathway", "Category", "Series"],
+                var_name="Year",
+                value_name="Value",
+            )
+            .pipe(
+                replace_nan_in_column,
+                table_name=sheet_name,
+                column_name="Category",
+                value="Residual emissions",
+            )
+            .pipe(
+                replace_nan_in_column,
+                table_name=sheet_name,
+                column_name="Value",
+                value=0,
+            )
+            .pipe(convert_sign_of_abatement, table_name=sheet_name)
+            .pipe(
+                assert_dtypes,
+                table_name=sheet_name,
+                expected_dtypes=table_dict.get("dtypes"),
+            )
+        )
+
+    if sheet_name in [
+        "7.2.1"
+    ]:  # Residential buildings emissions, historical and Balanced Pathway
+
+        skiprows = table_dict.get("skiprows")
+        if not skiprows:
+            raise ValueError("Missing 'skiprows' in table data.")
+
+        redundant_rows = [9]
+
+        table_df = (
+            pd.read_excel(content[file_url], sheet_name=sheet_name, skiprows=skiprows)
+            .pipe(drop_nan_columns, table_name=sheet_name)
+            .pipe(drop_row, table_name=sheet_name, index_list_to_drop=redundant_rows)
+            .pipe(
+                melt_dataframe,
+                table_name=sheet_name,
+                id_vars=["Series", "Subsector"],
+                var_name="Year",
+                value_name="Emissions (MtCO2e)",
+            )
+            .pipe(
+                replace_value_in_column,
+                table_name=sheet_name,
+                column_name="Emissions (MtCO2e)",
+                replaced_value=-10000,
+                replacement_value=0,
+            )
+            .pipe(
+                assert_dtypes,
+                table_name=sheet_name,
+                expected_dtypes=table_dict.get("dtypes"),
+            )
+        )
+
+    if sheet_name in [
+        "7.2.2"
+    ]:  # Sources of abatement in Balanced Pathway for residential buildings
+
+        skiprows = table_dict.get("skiprows")
+        if not skiprows:
+            raise ValueError("Missing 'skiprows' in table data.")
+
+        redundant_rows = [1, 7, 8, 9, 10]
+
+        column_map = {"Unnamed: 10": "Category"}
+
+        table_df = (
+            pd.read_excel(content[file_url], sheet_name=sheet_name, skiprows=skiprows)
+            .pipe(drop_nan_columns, table_name=sheet_name)
+            .pipe(drop_row, table_name=sheet_name, index_list_to_drop=redundant_rows)
+            .pipe(rename_columns, table_name=sheet_name, column_map=column_map)
+            .pipe(
+                add_constant_column,
+                table_name=sheet_name,
+                column_name="Pathway",
+                constant_value="Balanced Pathway",
+            )
+            .pipe(
+                melt_dataframe,
+                table_name=sheet_name,
+                id_vars=["Pathway", "Category"],
+                var_name="Year",
+                value_name="Value",
+            )
+            .pipe(
+                replace_nan_in_column,
+                table_name=sheet_name,
+                column_name="Category",
+                value="Residual emissions",
+            )
+            .pipe(
+                replace_nan_in_column,
+                table_name=sheet_name,
+                column_name="Value",
+                value=0,
+            )
+            .pipe(convert_sign_of_abatement, table_name=sheet_name)
+            .pipe(
+                assert_dtypes,
+                table_name=sheet_name,
+                expected_dtypes=table_dict.get("dtypes"),
+            )
+        )
+    if sheet_name in ["7.2.4"]:  # Key indicators for residential buildings
+
+        skiprows = table_dict.get("skiprows")
+        if not skiprows:
+            raise ValueError("Missing 'skiprows' in table data.")
+
+        table_df = (
+            pd.read_excel(
+                content[file_url],
+                sheet_name=sheet_name,
+                skiprows=skiprows,
+            )
+            .pipe(drop_nan_columns, table_name=sheet_name)
+            .pipe(
+                replace_nan_in_column,
+                table_name=sheet_name,
+                column_name="Unit",
+                value="-",
+            )
+            .pipe(
+                melt_dataframe,
+                table_name=sheet_name,
+                id_vars=["Name", "Unit", "Series"],
+                var_name="Year",
+                value_name="Value",
+            )
+            .pipe(
+                assert_dtypes,
+                table_name=sheet_name,
+                expected_dtypes=table_dict.get("dtypes"),
+            )
+        )
+
+    transformed_tables[sheet_name] = table_df
+
+# Load to s3 with transformation log as metadata
+s3_file_path = []
+for name, dataframe in transformed_tables.items():
+
+    metadata = {}
+    with open(log_file_path, "r") as log_file:
+        i = 1
+        for line in log_file:
+            if name in line:
+                metadata[f"bronze_to_silver_transformation_{i}"] = line
+                i = i + 1
+
+    # Encode metadata to parquet metadata via DataFrame attrs property
+    dataframe.attrs = metadata
+
+    # Get corresponding file url of table
+    for dict in latest_version.get("tables"):
+        if dict["sheet_name"] == name:
+            file_url = dict["file_url"]
+
+    file_path = save_to_s3_silver(
+        dataframe=dataframe,
+        dataset_name=dataset_name,
+        main_file_dict=latest_version,
+        file_url_index=latest_version["file_url"].index(file_url),
+        subset_id=name.replace(" ", "_").replace("-", "_").replace(".", "_"),
+    )
+    s3_file_path.append(file_path)
+
+# Append "file_silver" to config
+if not s3_file_path:
+    pass
+else:
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_silver",
+    )

--- a/asf_mission_data_tool/pipeline/seventh_carbon_budget_pipeline/get_seventh_carbon_budget_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/seventh_carbon_budget_pipeline/get_seventh_carbon_budget_to_bronze.py
@@ -1,0 +1,24 @@
+from asf_mission_data_tool.getters.data_getters import (
+    save_to_s3_bronze,
+    get_latest_version,
+    append_field_to_latest_version,
+)
+
+dataset_name = "seventh_carbon_budget"
+
+latest_version = get_latest_version(dataset_name)
+
+s3_file_path = []
+for file_url in latest_version.get("file_url"):
+    file_path = save_to_s3_bronze(dataset_name=dataset_name, target_url=file_url)
+    if file_path:
+        s3_file_path.append(file_path)
+
+if not s3_file_path:
+    pass
+else:
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_bronze",
+    )

--- a/asf_mission_data_tool/pipeline/sixth_carbon_budget_pipeline/get_sixth_carbon_budget_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/sixth_carbon_budget_pipeline/get_sixth_carbon_budget_to_bronze.py
@@ -1,0 +1,22 @@
+from asf_mission_data_tool.getters.data_getters import (
+    save_to_s3_bronze,
+    get_latest_version,
+    append_file_bronze_to_latest_version,
+)
+
+dataset_name = "sixth_carbon_budget"
+
+latest_version = get_latest_version(dataset_name)
+
+s3_file_path = []
+for file_url in latest_version.get("file_url"):
+    file_path = save_to_s3_bronze(dataset_name=dataset_name, target_url=file_url)
+    if file_path:
+        s3_file_path.append(file_path)
+
+if not s3_file_path:
+    pass
+else:
+    append_file_bronze_to_latest_version(
+        dataset_name=dataset_name, s3_file_path=s3_file_path
+    )

--- a/asf_mission_data_tool/pipeline/sixth_carbon_budget_pipeline/get_sixth_carbon_budget_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/sixth_carbon_budget_pipeline/get_sixth_carbon_budget_to_bronze.py
@@ -1,7 +1,7 @@
 from asf_mission_data_tool.getters.data_getters import (
     save_to_s3_bronze,
     get_latest_version,
-    append_file_bronze_to_latest_version,
+    append_field_to_latest_version,
 )
 
 dataset_name = "sixth_carbon_budget"
@@ -17,6 +17,8 @@ for file_url in latest_version.get("file_url"):
 if not s3_file_path:
     pass
 else:
-    append_file_bronze_to_latest_version(
-        dataset_name=dataset_name, s3_file_path=s3_file_path
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_bronze",
     )

--- a/asf_mission_data_tool/pipeline/uk_territorial_greenhouse_gas_emissions_statistics_pipeline/bronze_to_silver_uk_territorial_greenhouse_gas_emissions_statistics.py
+++ b/asf_mission_data_tool/pipeline/uk_territorial_greenhouse_gas_emissions_statistics_pipeline/bronze_to_silver_uk_territorial_greenhouse_gas_emissions_statistics.py
@@ -1,0 +1,193 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     comment_magics: true
+#     custom_cell_magics: kql
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.2
+#   kernelspec:
+#     display_name: asf_mission_data_tool
+#     language: python
+#     name: python3
+# ---
+
+# %%
+import pandas as pd
+
+# %%
+from asf_mission_data_tool.getters.data_getters import (
+    get_from_s3,
+    save_to_s3_silver,
+    append_field_to_latest_version,
+    get_latest_version,
+)
+
+# %%
+from asf_mission_data_tool.getters.bronze_to_silver_transformations import (
+    set_logger,
+    forward_fill_nan_by_column,
+    fill_sector_category_columns,
+    check_missing_values,
+    assert_dtypes,
+    melt_dataframe,
+    convert_year_column_to_int,
+    rename_columns,
+    add_constant_column,
+)
+
+# %%
+# Dataset specific variables
+dataset_name = "uk_territorial_greenhouse_gas_emissions_statistics"
+latest_version = get_latest_version(dataset_name, filter="final")
+log_file_path = dataset_name + ".log"
+
+# %%
+# Set up logger for transformation tracking
+set_logger(log_file_path)
+
+# %%
+# Check table-level information is available
+tables = latest_version.get("tables")
+if not tables:
+    raise ValueError("No 'tables' key found in config, or 'tables' is empty.")
+
+# %%
+# Download file content from s3
+content = {}
+for file_url in latest_version.get("file_url"):
+    file_name = file_url.split("/")[-1]
+    bronze_key = [
+        file_bronze
+        for file_bronze in latest_version.get("file_bronze")
+        if file_name in file_bronze
+    ][0].replace("s3://asf-mission-data-tool/", "")
+    content[file_url] = get_from_s3(s3_key=bronze_key)
+
+# %%
+# Read and series transformations for each table in dataset
+transformed_tables = {}
+for table_dict in latest_version.get("tables"):
+
+    # Extract information
+    sheet_name = table_dict.get("sheet_name")
+    if not sheet_name:
+        raise ValueError("Missing 'sheet_name' in table data.")
+
+    skiprows = table_dict.get("skiprows")
+    if not skiprows:
+        raise ValueError("Missing 'skiprows' in table data.")
+
+    dtypes = table_dict.get("dtypes")
+
+    file_url = table_dict.get("file_url")
+
+    # Raise error if more tables are added
+    if sheet_name not in ["1.2", "7.1"]:
+        raise ValueError(
+            "New tables have been added that are not currently accounted for in pipeline."
+        )
+
+    table_df = (
+        pd.read_excel(content[file_url], sheet_name=sheet_name, skiprows=skiprows)
+        .pipe(
+            forward_fill_nan_by_column,
+            table_name=sheet_name,
+            column_name="TES sector",
+        )
+        .pipe(
+            forward_fill_nan_by_column,
+            table_name=sheet_name,
+            column_name="TES subsector",
+        )
+    ).pipe(
+        fill_sector_category_columns,
+        table_name=sheet_name,
+        sector_column="TES sector",
+        subsector_column="TES subsector",
+        category_column="TES category",
+    )
+
+    column_map = {
+        "TES sector": "tes_sector",
+        "TES subsector": "tes_subsector",
+        "TES category": "tes_category",
+        "Year": "year",
+        "Territorial greenhouse gas emissions (MtCO2e)": "territorial_greenhouse_gas_emissions",
+    }
+
+    table_df = (
+        table_df.pipe(check_missing_values, table_name=sheet_name)
+        .pipe(
+            melt_dataframe,
+            table_name=sheet_name,
+            id_vars=[
+                "TES sector",
+                "TES subsector",
+                "TES category",
+            ],  # These were TES Sector, TES Subsector, TES Category in 2022 version
+            var_name="Year",
+            value_name="Territorial greenhouse gas emissions (MtCO2e)",
+        )
+        .pipe(
+            convert_year_column_to_int, table_name=sheet_name, year_column_name="Year"
+        )
+        .pipe(rename_columns, table_name=sheet_name, column_map=column_map)
+        .pipe(
+            add_constant_column,
+            table_name=sheet_name,
+            column_name="unit",
+            constant_value="MtCO2e",
+        )
+        .pipe(
+            assert_dtypes,
+            table_name=sheet_name,
+            expected_dtypes=table_dict.get("dtypes"),
+        )
+    )
+    transformed_tables[sheet_name] = table_df
+
+# %%
+# Load to s3 with transformation log as metadata
+s3_file_path = []
+for name, dataframe in transformed_tables.items():
+
+    metadata = {}
+    with open(log_file_path, "r") as log_file:
+        i = 1
+        for line in log_file:
+            if name in line:
+                metadata[f"bronze_to_silver_transformation_{i}"] = line
+                i = i + 1
+
+    # Encode metadata to parquet metadata via DataFrame attrs property
+    dataframe.attrs = metadata
+
+    # Get corresponding file url of table
+    for dict in latest_version.get("tables"):
+        if dict["sheet_name"] == name:
+            file_url = dict["file_url"]
+
+    file_path = save_to_s3_silver(
+        dataframe=dataframe,
+        dataset_name=dataset_name,
+        main_file_dict=latest_version,
+        file_url_index=latest_version["file_url"].index(file_url),
+        subset_id=name.replace(".", "_"),
+    )
+    s3_file_path.append(file_path)
+
+# %%
+# Append "file_silver" to config
+if not s3_file_path:
+    pass
+else:
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_silver",
+        filter="final",
+    )

--- a/asf_mission_data_tool/pipeline/uk_territorial_greenhouse_gas_emissions_statistics_pipeline/get_uk_territorial_greenhouse_gas_emissions_statistics_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/uk_territorial_greenhouse_gas_emissions_statistics_pipeline/get_uk_territorial_greenhouse_gas_emissions_statistics_to_bronze.py
@@ -1,0 +1,24 @@
+from asf_mission_data_tool.getters.data_getters import (
+    save_to_s3_bronze,
+    get_latest_version,
+    append_file_bronze_to_latest_version,
+)
+
+dataset_name = "uk_territorial_greenhouse_gas_emissions_statistics"
+
+latest_version = get_latest_version(dataset_name)
+
+s3_file_path = []
+for file_url in latest_version.get("file_url"):
+    file_path = save_to_s3_bronze(dataset_name=dataset_name, target_url=file_url)
+    if file_path:
+        s3_file_path.append(file_path)
+
+if not s3_file_path:
+    pass
+else:
+    append_file_bronze_to_latest_version(
+        dataset_name=dataset_name, s3_file_path=s3_file_path
+    )
+
+# Note: Might want to focus on the lastest *final* version, as the most recent is *provisional*

--- a/asf_mission_data_tool/pipeline/uk_territorial_greenhouse_gas_emissions_statistics_pipeline/get_uk_territorial_greenhouse_gas_emissions_statistics_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/uk_territorial_greenhouse_gas_emissions_statistics_pipeline/get_uk_territorial_greenhouse_gas_emissions_statistics_to_bronze.py
@@ -1,12 +1,12 @@
 from asf_mission_data_tool.getters.data_getters import (
     save_to_s3_bronze,
     get_latest_version,
-    append_file_bronze_to_latest_version,
+    append_field_to_latest_version,
 )
 
 dataset_name = "uk_territorial_greenhouse_gas_emissions_statistics"
 
-latest_version = get_latest_version(dataset_name)
+latest_version = get_latest_version(dataset_name, filter="final")
 
 s3_file_path = []
 for file_url in latest_version.get("file_url"):
@@ -17,8 +17,9 @@ for file_url in latest_version.get("file_url"):
 if not s3_file_path:
     pass
 else:
-    append_file_bronze_to_latest_version(
-        dataset_name=dataset_name, s3_file_path=s3_file_path
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        filter="final",
+        new_field_name="file_bronze",
     )
-
-# Note: Might want to focus on the lastest *final* version, as the most recent is *provisional*

--- a/asf_mission_data_tool/pipeline/welsh_housing_conditions_survey_pipeline/get_welsh_housing_conditions_survey_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/welsh_housing_conditions_survey_pipeline/get_welsh_housing_conditions_survey_to_bronze.py
@@ -1,0 +1,22 @@
+from asf_mission_data_tool.getters.data_getters import (
+    save_to_s3_bronze,
+    get_latest_version,
+    append_file_bronze_to_latest_version,
+)
+
+dataset_name = "welsh_housing_conditions_survey"
+
+latest_version = get_latest_version(dataset_name)
+
+s3_file_path = []
+for file_url in latest_version.get("file_url"):
+    file_path = save_to_s3_bronze(dataset_name=dataset_name, target_url=file_url)
+    if file_path:
+        s3_file_path.append(file_path)
+
+if not s3_file_path:
+    pass
+else:
+    append_file_bronze_to_latest_version(
+        dataset_name=dataset_name, s3_file_path=s3_file_path
+    )

--- a/asf_mission_data_tool/pipeline/welsh_housing_conditions_survey_pipeline/get_welsh_housing_conditions_survey_to_bronze.py
+++ b/asf_mission_data_tool/pipeline/welsh_housing_conditions_survey_pipeline/get_welsh_housing_conditions_survey_to_bronze.py
@@ -1,7 +1,7 @@
 from asf_mission_data_tool.getters.data_getters import (
     save_to_s3_bronze,
     get_latest_version,
-    append_file_bronze_to_latest_version,
+    append_field_to_latest_version,
 )
 
 dataset_name = "welsh_housing_conditions_survey"
@@ -17,6 +17,8 @@ for file_url in latest_version.get("file_url"):
 if not s3_file_path:
     pass
 else:
-    append_file_bronze_to_latest_version(
-        dataset_name=dataset_name, s3_file_path=s3_file_path
+    append_field_to_latest_version(
+        dataset_name=dataset_name,
+        s3_file_path=s3_file_path,
+        new_field_name="file_bronze",
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+boto3
+toml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 boto3
 toml
 odfpy
+pandas
+beautifulsoup4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 boto3
 toml
+odfpy


### PR DESCRIPTION
In this branch, I've done all development for getting each dataset to bronze, and processing it to silver. 

Note: The branch https://github.com/nestauk/asf_mission_data_tool/tree/1-move-dataset-of-interest-from-published-location-online-to-s3 is redundant now as all changes made in that branch is in this one.

The main components are:
- Information on all datasets stored in `config/base.yaml`
- Getter functions in `getters/data_getters.py`
- In the `pipeline` folder, there is an individual folder for each dataset where we're aiming to have three files:
i. `update_[dataset_name].py`: Checks the dataset collection source webpage for the latest release and adds information about the latest version to config if it doesn't exist already.
ii. `get_[dataset_name]_to_bronze.py`: Gets the raw data files from the dataset page URL and saves it to S3.
iii. `bronze_to_silver_[dataset_name].py`: Processes each bronze data file into silver format and saves it to S3.

**November 2025 update:** We are migrating these pipelines to the repo https://github.com/nestauk/asf_mission_data and integrating them in use of Apache Airflow. This repo and branch will now be used for development and testing purposes only.